### PR TITLE
2022 / Gradle 7.0 Prep

### DIFF
--- a/build_scripts/bazel/deps/download_external_archives.bzl
+++ b/build_scripts/bazel/deps/download_external_archives.bzl
@@ -14,9 +14,9 @@ def download_external_archives():
     # Download BazelRio <3
     http_archive(
         name = "bazelrio",
-        url = "https://github.com/bazelRio/bazelRio/archive/refs/tags/0.3.0.zip",
-        sha256 = "f48dd081ccbca0f63d7577e68399d30ecbf85e935cad08dfa24f56691f4e8c85",
-        strip_prefix = "bazelRio-0.3.0/bazelrio",
+        url = "https://github.com/bazelRio/bazelRio/archive/ef3c34a60f0eaeea41b05ca1b01742b3a5c85008.tar.gz",
+        sha256 = "86e0ef386c6d4aec69f737c4aa821f04826686b6e54d892e157e1eae378c2702",
+        strip_prefix = "bazelRio-ef3c34a60f0eaeea41b05ca1b01742b3a5c85008/bazelrio",
     )
 
     # Download Setup python

--- a/build_scripts/bazel/deps/setup_dependencies.bzl
+++ b/build_scripts/bazel/deps/setup_dependencies.bzl
@@ -4,5 +4,13 @@ load("@bazelrio//:deps.bzl", "setup_bazelrio_dependencies")
 
 def setup_dependencies():
     rules_pmd_dependencies()
-    setup_bazelrio_dependencies()
+    setup_bazelrio_dependencies(
+        toolchain_versions = "2021",
+        wpilib_version = "2021.3.1",
+        ni_version = "2020.9.2",
+        opencv_version = "3.4.7-5",
+        sparkmax_version = "1.5.4",
+        phoenix_version = "5.19.4",
+        navx_version = "4.0.425",
+    )
     setup_bazelrio()

--- a/codelabs/basic_java/build.gradle
+++ b/codelabs/basic_java/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    testRuntime("org.junit.vintage:junit-vintage-engine:5.2.0")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.2.0")
 }
 
 test {

--- a/codelabs/pid/BUILD.bazel
+++ b/codelabs/pid/BUILD.bazel
@@ -12,6 +12,7 @@ gos_java_robot(
         "@bazelrio//libraries/java/wpilib/ntcore",
         "@bazelrio//libraries/java/wpilib/wpilibj",
         "@bazelrio//libraries/java/wpilib/wpimath",
+        "@bazelrio//libraries/java/wpilib/wpiutil",
         "@snobot_sim//jar",
     ],
 )

--- a/codelabs/pid/build.gradle
+++ b/codelabs/pid/build.gradle
@@ -67,8 +67,8 @@ dependencies {
     // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, false)
     // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, false)
 
-    compile project(":libraries:GirlsOfSteelLib")
-    compile project(":libraries:GirlsOfSteelLibRev")
+    implementation project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLibRev")
 }
 
 // Simulation configuration (e.g. environment variables).

--- a/libraries/GirlsOfSteelLib/BUILD.bazel
+++ b/libraries/GirlsOfSteelLib/BUILD.bazel
@@ -6,5 +6,6 @@ gos_java_library(
     visibility = ["//visibility:public"],
     deps = [
         "@bazelrio//libraries/java/wpilib/wpilibj",
+        "@bazelrio//libraries/java/wpilib/wpimath",
     ],
 )

--- a/libraries/GirlsOfSteelLibCtre/build.gradle
+++ b/libraries/GirlsOfSteelLibCtre/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation wpi.deps.wpilib()
     implementation wpi.deps.vendor.java()
-    compile project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLib")
 }
 
 test {

--- a/libraries/GirlsOfSteelLibNavx/build.gradle
+++ b/libraries/GirlsOfSteelLibNavx/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation wpi.deps.wpilib()
     implementation wpi.deps.vendor.java()
-    compile project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLib")
 }
 
 test {

--- a/libraries/GirlsOfSteelLibRev/build.gradle
+++ b/libraries/GirlsOfSteelLibRev/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     implementation wpi.deps.wpilib()
     implementation wpi.deps.vendor.java()
-    compile project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLib")
 }
 
 test {

--- a/libraries/build_scripts/custom_dashboard_helper.gradle
+++ b/libraries/build_scripts/custom_dashboard_helper.gradle
@@ -49,13 +49,13 @@ compileJava.dependsOn generate_version
 
 dependencies {
 
-    compile "org.openjfx:javafx-base:11:win"
-    compile "org.openjfx:javafx-graphics:11:win"
-    compile "org.openjfx:javafx-controls:11:win"
-    compile "org.openjfx:javafx-fxml:11:win"
+    implementation "org.openjfx:javafx-base:11:win"
+    implementation "org.openjfx:javafx-graphics:11:win"
+    implementation "org.openjfx:javafx-controls:11:win"
+    implementation "org.openjfx:javafx-fxml:11:win"
 
 
-    compile 'edu.wpi.first.shuffleboard:shuffleboard:' + shuffleboard_version
-    compile 'edu.wpi.first.shuffleboard:api:' + shuffleboard_version
-    compile 'edu.wpi.first.shuffleboard:api:' + shuffleboard_version
+    implementation 'edu.wpi.first.shuffleboard:shuffleboard:' + shuffleboard_version
+    implementation 'edu.wpi.first.shuffleboard:api:' + shuffleboard_version
+    implementation 'edu.wpi.first.shuffleboard:api:' + shuffleboard_version
 }

--- a/old_robots/y2017/Secondary_Human_Training_Golem/BUILD.bazel
+++ b/old_robots/y2017/Secondary_Human_Training_Golem/BUILD.bazel
@@ -8,6 +8,7 @@ gos_java_robot(
     deps = [
         "@bazelrio//libraries/java/ctre/phoenix",
         "@bazelrio//libraries/java/opencv",
+        "@bazelrio//libraries/java/wpilib/cameraserver",
         "@bazelrio//libraries/java/wpilib/cscore",
         "@bazelrio//libraries/java/wpilib/ntcore",
         "@bazelrio//libraries/java/wpilib/old_commands",

--- a/styleguide/styleguide.gradle
+++ b/styleguide/styleguide.gradle
@@ -21,8 +21,7 @@ jacoco {
 
 checkstyle {
     toolVersion = "9.0"
-    configDir = file("${project.rootDir}/styleguide")
-    config = resources.text.fromFile(new File(configDir, "checkstyle.xml"))
+    configDirectory.set(file("${project.rootDir}/styleguide"))
 }
 
 pmd {

--- a/y2019/2019DeepSpace/build.gradle
+++ b/y2019/2019DeepSpace/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, false)
     // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, false)
 
-    compile project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLib")
 }
 
 // Simulation configuration (e.g. environment variables).

--- a/y2020/2020InfiniteRecharge/BUILD.bazel
+++ b/y2020/2020InfiniteRecharge/BUILD.bazel
@@ -19,6 +19,7 @@ gos_java_robot(
         "@bazelrio//libraries/java/wpilib/ntcore",
         "@bazelrio//libraries/java/wpilib/wpilibj",
         "@bazelrio//libraries/java/wpilib/wpimath",
+        "@bazelrio//libraries/java/wpilib/wpiutil",
         "@snobot_sim//jar",
     ],
 )

--- a/y2020/2020InfiniteRecharge/build.gradle
+++ b/y2020/2020InfiniteRecharge/build.gradle
@@ -63,10 +63,10 @@ dependencies {
     // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, false)
     // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, false)
 
-    compile project(":libraries:GirlsOfSteelLib")
-    compile project(":libraries:GirlsOfSteelLibCtre")
-    compile project(":libraries:GirlsOfSteelLibNavx")
-    compile project(":libraries:GirlsOfSteelLibRev")
+    implementation project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLibCtre")
+    implementation project(":libraries:GirlsOfSteelLibNavx")
+    implementation project(":libraries:GirlsOfSteelLibRev")
 }
 
 // Simulation configuration (e.g. environment variables).

--- a/y2020/Testboard/build.gradle
+++ b/y2020/Testboard/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     // upon debugging
     simulation wpi.deps.sim.gui(wpi.platforms.desktop, false)
 
-    compile project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLib")
 }
 
 // Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')

--- a/y2021/OutreachBot/build.gradle
+++ b/y2021/OutreachBot/build.gradle
@@ -63,8 +63,8 @@ dependencies {
     // simulation wpi.deps.sim.ws_server(wpi.platforms.desktop, false)
     // simulation wpi.deps.sim.ws_client(wpi.platforms.desktop, false)
 
-    compile project(":libraries:GirlsOfSteelLib")
-    compile project(":libraries:GirlsOfSteelLibRev")
+    implementation project(":libraries:GirlsOfSteelLib")
+    implementation project(":libraries:GirlsOfSteelLibRev")
 }
 
 // Simulation configuration (e.g. environment variables).


### PR DESCRIPTION
Did a dry run of upgrading our code to 2022 beta. `compile` has been removed in the newest version of gradle (and was deprecated in 6.0). The update scripts don't account for this, so preempt it for when the girls do the 2021 -> 2022 upgrade.