### PR TITLE
[monorepo] CI, dashboard gen updates, building this year with bazel

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # TODO(PJ) Mac seems flakey on github. Turning it off for now
         # platform: [ubuntu-latest, macos-latest, windows-latest]
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
@@ -34,10 +34,28 @@ jobs:
       - name: Install Buildifier
         run: |
           cd $(mktemp -d)
-          GO111MODULE=on go get github.com/bazelbuild/buildtools/buildifier@4.0.1
+          GO111MODULE=on go get github.com/bazelbuild/buildtools/buildifier@5.0.1
+
+      - name: Install Unused Deps
+        run: |
+          cd $(mktemp -d)
+          GO111MODULE=on go get github.com/bazelbuild/buildtools/unused_deps@5.0.1
 
       - name: Run buildifier
         run: buildifier --lint=fix -r .
 
+      - name: Run unused deps
+        run: unused_deps //...
+
       - name: Check Output
         run: git --no-pager diff --exit-code HEAD
+
+      - name: Generate diff
+        run: git diff HEAD > bazel-lint-fixes.patch
+        if: ${{ failure() }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.platform }}-bazel-lint-fixes
+          path: bazel-lint-fixes.patch
+        if: ${{ failure() }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,6 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: lint-version-fixes
+          name: ${{ matrix.platform }}-lint-version-fixes
           path: lint-version-fixes.patch
         if: ${{ failure() }}

--- a/.github/workflows/shuffleboard_gen.yml
+++ b/.github/workflows/shuffleboard_gen.yml
@@ -30,9 +30,23 @@ jobs:
         run: python generate_dashboard.py --config_file=../../y2021/OutreachBotDashboard/dashboard.yml
         working-directory: libraries/ShuffleboardGenerator
 
+      - name: Re-gen 2022
+        run: python generate_dashboard.py --config_file=../../y2022/RapidReactDashboard/dashboard.yml
+        working-directory: libraries/ShuffleboardGenerator
+
       - name: Check output
         run: git --no-pager diff --exit-code HEAD
       - name: Print Debug Message
         if: ${{ failure() }}
         run: |
           echo "::error:: The automatic generation script for the shuffleboard plugin is producing different code than what has been comitted"
+
+      - name: Generate diff
+        run: git diff HEAD > shuffleboard-fixes.patch
+        if: ${{ failure() }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.platform }}-shuffleboard-fixes
+          path: shuffleboard-fixes.patch
+        if: ${{ failure() }}

--- a/codelabs/custom_shuffleboard/src/dashboard_gen/java/com/gos/codelabs/shuffleboard/sd_widgets/ss/ElevatorData.java
+++ b/codelabs/custom_shuffleboard/src/dashboard_gen/java/com/gos/codelabs/shuffleboard/sd_widgets/ss/ElevatorData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class ElevatorData extends ComplexData<ElevatorData> {
 
     private final double m_speed;

--- a/codelabs/custom_shuffleboard/src/dashboard_gen/java/com/gos/codelabs/shuffleboard/sd_widgets/ss/PunchData.java
+++ b/codelabs/custom_shuffleboard/src/dashboard_gen/java/com/gos/codelabs/shuffleboard/sd_widgets/ss/PunchData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class PunchData extends ComplexData<PunchData> {
 
     private final boolean m_punchExtended;

--- a/codelabs/custom_shuffleboard/src/dashboard_gen/java/com/gos/codelabs/shuffleboard/sd_widgets/ss/SpinningWheelData.java
+++ b/codelabs/custom_shuffleboard/src/dashboard_gen/java/com/gos/codelabs/shuffleboard/sd_widgets/ss/SpinningWheelData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class SpinningWheelData extends ComplexData<SpinningWheelData> {
 
     private final double m_speed;

--- a/libraries/ShuffleboardGenerator/lib/generate_dashboard_structure.py
+++ b/libraries/ShuffleboardGenerator/lib/generate_dashboard_structure.py
@@ -134,8 +134,6 @@ class WidgetGenerator:
     def verify_config(self):
         if len(self.widget_config['children_tables']) == 1:
             child = self.widget_config['children_tables'][0]
-            print(self.widget_config)
-            print(child)
             if self.widget_config['table'] != child['table']:
                 raise Exception(f"If you only have one child, some short circuits will be used. Because of that, the widget table ('{self.widget_config['table']}') must matach the child table ('{child['table']}')")
 
@@ -170,7 +168,9 @@ class TopLevelGenerator:
         template_output = self._load_template('java/Utils.java.txt').render(overall_config=self.overall_config)
 
         output_file = os.path.join(self.plugin_dump_main_dir, "Utils.java")
-        open(output_file, 'w').write(template_output)
+
+        if force or not os.path.exists(output_file):
+            open(output_file, 'w').write(template_output)
 
 
 def maybe_add_standalone_buttons(widget_config):

--- a/libraries/ShuffleboardGenerator/lib/template_helpers.py
+++ b/libraries/ShuffleboardGenerator/lib/template_helpers.py
@@ -5,6 +5,8 @@ import os
 
 
 def _lower_first_char(input_str):
+    if len(input_str) == 0:
+        raise Exception("Cannot use an empty string for a field name!")
     return input_str[0].lower() + input_str[1:]
 
 
@@ -15,6 +17,9 @@ def camel_to_snake(input_str):
 
 def _upper_snake_to_camel(input_str):
     components = input_str.lower().split('_')
+    if len(components) == 0:
+        raise Exception("Cannot use an empty string!")
+
     output = components[0] + ''.join(x.title() for x in components[1:])
     output = output[0].upper() + output[1:]
     return output
@@ -73,7 +78,9 @@ def _on_key_released(child, entry, array_index = None):
 
     if entry['type'] == "double":
         if 'sim_value' in entry:
-            template_file = "java/keyboard_templates/key_released_sim.txt"
+            template_file = "java/keyboard_templates/key_released_sim_value.txt"
+        elif "sim_incr" in entry:
+            template_file = "java/keyboard_templates/key_released_sim_incr.txt"
 
     elif entry['type'] == "boolean":
         template_file = "java/keyboard_templates/key_released_boolean.txt"
@@ -95,6 +102,20 @@ def _on_key_released(child, entry, array_index = None):
     output = template.render(child=child, entry=entry)
 
     return output
+
+
+def _get_keys(child, entry, array_index=None):
+    if entry["type"] == "double":
+        return f"{entry['sim_keys'][0]}/{entry['sim_keys'][1]}"
+    elif entry["type"] == "boolean":
+        return f"{entry['sim_keys']}"
+    elif _is_array(entry):
+        un_arrayed = entry.copy()
+        un_arrayed["type"] = un_arrayed["type"][:-2]
+        un_arrayed["name"] += str(array_index)
+        return _get_keys(child, un_arrayed)
+    else:
+        return "UNKNOWN"
 
 
 def _on_key_pressed(child, entry, array_index=None):
@@ -135,7 +156,8 @@ def _add_template_functions(template):
     template.globals['package_to_dir'] = package_to_dir
     template.globals['cap_first_char'] = _cap_first_char
     template.globals['on_key_pressed'] = _on_key_pressed
-    template.globals['on_key_released'] = _on_key_released
+    template.globals["get_keys"] = _get_keys
+    template.globals["on_key_released"] = _on_key_released
     template.globals['getter_name'] = _getter_name
     template.globals['default_value_lookup'] = _default_value_lookup
     template.globals['is_array'] = _is_array

--- a/libraries/ShuffleboardGenerator/lib/templates/dashboard_gen/widget/data_template.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/dashboard_gen/widget/data_template.txt
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class {{child.table}}Data extends ComplexData<{{child.table}}Data> {
 {%- for variable in child.entries %}
 {%- if is_array(variable) %}

--- a/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_press_boolean.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_press_boolean.txt
@@ -1,4 +1,5 @@
 
             case {{entry.sim_keys}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} = true;
+                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.GREEN);
                 break;

--- a/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_press_sim_incr.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_press_sim_incr.txt
@@ -1,6 +1,8 @@
             case {{entry.sim_keys[0]}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} -= {{entry.sim_incr}};
+                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.GREEN);
                 break;
             case {{entry.sim_keys[1]}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} += {{entry.sim_incr}};
+                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.GREEN);
                 break;

--- a/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_press_sim_value.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_press_sim_value.txt
@@ -1,6 +1,8 @@
             case {{entry.sim_keys[0]}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} = {{entry.sim_value}};
+                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.GREEN);
                 break;
             case {{entry.sim_keys[1]}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} = -{{entry.sim_value}};
+                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.GREEN);
                 break;

--- a/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_released_sim_incr.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_released_sim_incr.txt
@@ -1,5 +1,4 @@
-
-            case {{entry.sim_keys}}:
-                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} = false;
+            case {{entry.sim_keys[0]}}:
+            case {{entry.sim_keys[1]}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.BLACK);
                 break;

--- a/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_released_sim_value.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/java/keyboard_templates/key_released_sim_value.txt
@@ -1,4 +1,5 @@
             case {{entry.sim_keys[0]}}:
             case {{entry.sim_keys[1]}}:
                 m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}} = 0;
+                m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label.setTextFill(Color.BLACK);
                 break;

--- a/libraries/ShuffleboardGenerator/lib/templates/java/standalone_main_template.txt
+++ b/libraries/ShuffleboardGenerator/lib/templates/java/standalone_main_template.txt
@@ -3,17 +3,26 @@ package {{widget_package_name}};
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
+import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.BorderStroke;
+import javafx.scene.layout.BorderStrokeStyle;
+import javafx.scene.layout.BorderWidths;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 import java.io.IOException;
 {%- if widget.children_tables|length != 1 %}
 import java.util.HashMap;
-import java.util.Map;
 {%- endif %}
+import java.util.Map;
 
-@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
+@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity", "PMD.TooManyFields"})
 public class {{widget.table}}StandaloneMain {
     private final {{widget.table}}Widget m_controller;
 {% for child in widget.children_tables %}
@@ -28,8 +37,36 @@ public class {{widget.table}}StandaloneMain {
   {%- endfor %}
 {%- endfor %}
 
+{% for child in widget.children_tables %}
+  {%- for entry in child.entries %}
+    {%- if is_array(entry) %}
+      {%- for i in range(5) %}
+    private final Label m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}{{i}}Label = new Label("{{get_keys(child, entry, i)}} -> {{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}");
+      {%- endfor %}
+    {%- else %}
+    private final Label m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label = new Label("{{get_keys(child, entry)}} -> {{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}");
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+
     public {{widget.table}}StandaloneMain(Scene scene, {{widget.table}}Widget robotController) {
         m_controller = robotController;
+
+        VBox labelPane = new VBox();
+        labelPane.setBorder(new Border(new BorderStroke(Color.BLACK,
+            BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT)));
+{% for child in widget.children_tables %}
+  {%- for entry in child.entries %}
+    {%- if is_array(entry) %}
+      {%- for i in range(5) %}
+        labelPane.getChildren().add(m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}{{i}}Label);
+      {%- endfor %}
+    {%- else %}
+        labelPane.getChildren().add(m_{{lower_first_char(child.table)}}{{cap_first_char(entry.name)}}Label);
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
+        ((BorderPane) scene.getRoot()).setBottom(labelPane);
 
         scene.setOnKeyPressed(event -> {
             KeyCode code = event.getCode();
@@ -89,6 +126,11 @@ public class {{widget.table}}StandaloneMain {
               {%- endif %}
             {%- endfor %}
             );
+
+            final SuperStructureData oldData =  m_controller.dataProperty().getValue();
+            Map<String, Object> changes = data.changesFrom(oldData);
+            System.out.println(changes);
+
             m_controller.dataProperty().setValue(data);
 {%- else %}
             Map<String, Object> map = new HashMap<>();
@@ -99,6 +141,11 @@ public class {{widget.table}}StandaloneMain {
   {%- endfor %}
                 ).asMap(SmartDashboardNames.{{child.table_name}} + "/"));
 {% endfor %}
+
+            final SuperStructureData oldData =  m_controller.dataProperty().getValue();
+            Map<String, Object> changes = data.changesFrom(oldData);
+            System.out.println(changes);
+
             m_controller.dataProperty().setValue(new {{widget.table}}Data(map));
 {% endif %}
         } catch (ClassCastException ignored) {

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/control_panel/ControlPanelData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/control_panel/ControlPanelData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class ControlPanelData extends ComplexData<ControlPanelData> {
 
     private final Double m_simAngle;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/leds/LedData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/leds/LedData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class LedData extends ComplexData<LedData> {
 
     private final String m_values;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ControlPanelData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ControlPanelData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class ControlPanelData extends ComplexData<ControlPanelData> {
 
     private final double m_speed;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/LiftData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/LiftData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class LiftData extends ComplexData<LiftData> {
 
     private final double m_speed;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ShooterConveyorData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ShooterConveyorData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class ShooterConveyorData extends ComplexData<ShooterConveyorData> {
 
     private final double m_speed;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ShooterIntakeData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ShooterIntakeData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class ShooterIntakeData extends ComplexData<ShooterIntakeData> {
 
     private final double m_speed;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ShooterWheelsData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/ShooterWheelsData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class ShooterWheelsData extends ComplexData<ShooterWheelsData> {
 
     private final double m_currentRpm;

--- a/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/WinchData.java
+++ b/y2020/2020InfiniteRechargeDashboard/src/dashboard_gen/java/com/gos/infinite_recharge/sd_widgets/super_structure/WinchData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class WinchData extends ComplexData<WinchData> {
 
     private final double m_speed;

--- a/y2021/OutreachBotDashboard/src/dashboard_gen/java/com/gos/outreach/shuffleboard/super_structure/SuperStructureData.java
+++ b/y2021/OutreachBotDashboard/src/dashboard_gen/java/com/gos/outreach/shuffleboard/super_structure/SuperStructureData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD.DataClass")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class SuperStructureData extends ComplexData<SuperStructureData> {
 
     private final double m_hoodAngle;

--- a/y2022/RapidReact/BUILD.bazel
+++ b/y2022/RapidReact/BUILD.bazel
@@ -1,0 +1,24 @@
+load("//build_scripts/bazel:java_rules.bzl", "gos_java_robot")
+
+gos_java_robot(
+    name = "RapidReact",
+    srcs = glob(["src/main/java/**/*.java"]),
+    data = glob(["src/main/deploy/**"]),
+    main_class = "com.gos.rapidreact.Main",
+    deps = [
+        "//libraries/GirlsOfSteelLib",
+        "//libraries/GirlsOfSteelLibCtre",
+        "//libraries/GirlsOfSteelLibNavx",
+        "//libraries/GirlsOfSteelLibRev",
+        "@bazelrio//libraries/java/ctre/phoenix",
+        "@bazelrio//libraries/java/rev/revlib",
+        "@bazelrio//libraries/java/wpilib/cameraserver",
+        "@bazelrio//libraries/java/wpilib/cscore",
+        "@bazelrio//libraries/java/wpilib/new_commands",
+        "@bazelrio//libraries/java/wpilib/ntcore",
+        "@bazelrio//libraries/java/wpilib/wpilibj",
+        "@bazelrio//libraries/java/wpilib/wpimath",
+        "@bazelrio//libraries/java/wpilib/wpiutil",
+        "@snobot_sim//jar",
+    ],
+)

--- a/y2022/RapidReactDashboard/BUILD.bazel
+++ b/y2022/RapidReactDashboard/BUILD.bazel
@@ -1,0 +1,14 @@
+load("//build_scripts/bazel:java_rules.bzl", "gos_java_binary")
+load("//build_scripts/bazel/shuffleboard:shuffleboard_widget.bzl", "shuffleboard_widget")
+
+shuffleboard_widget(
+    name = "RapidReactDashboard",
+    generation_config_file = ":dashboard.yml",
+    package = "com.gos.rapidreact.shuffleboard",
+)
+
+gos_java_binary(
+    name = "SuperStructureMain",
+    main_class = "com.gos.rapidreact.shuffleboard.super_structure.SuperStructureStandaloneMain",
+    runtime_deps = [":RapidReactDashboard"],
+)

--- a/y2022/RapidReactDashboard/README.md
+++ b/y2022/RapidReactDashboard/README.md
@@ -1,0 +1,5 @@
+# Rapid React Dashboard
+Shuffleboard plugins for the 2022 FRC Competition.
+
+Regenerate the dashboard with 
+`py  libraries/ShuffleboardGenerator/generate_dashboard.py --config=y2022/RapidReactDashboard/dashboard.yml --force_standalone_main`

--- a/y2022/RapidReactDashboard/src/dashboard_gen/java/com/gos/rapidreact/shuffleboard/super_structure/SuperStructureData.java
+++ b/y2022/RapidReactDashboard/src/dashboard_gen/java/com/gos/rapidreact/shuffleboard/super_structure/SuperStructureData.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-@SuppressWarnings("PMD")
+@SuppressWarnings({"PMD.DataClass", "PMD.ExcessiveParameterList"})
 public class SuperStructureData extends ComplexData<SuperStructureData> {
 
     private final double m_intakeAngle;

--- a/y2022/RapidReactDashboard/src/main/java/com/gos/rapidreact/shuffleboard/super_structure/SuperStructureController.java
+++ b/y2022/RapidReactDashboard/src/main/java/com/gos/rapidreact/shuffleboard/super_structure/SuperStructureController.java
@@ -186,9 +186,11 @@ public class SuperStructureController {
 
     public void updateSuperStructure(SuperStructureData superStructureData) {
 
+        double javafxAngle = 90 - superStructureData.getIntakeAngle();
+
         m_intake.setStroke(Utils.getMotorColor(superStructureData.getIntakeSpeed()));
         m_intakeWheel.setFill(Utils.getMotorColor(superStructureData.getRollerSpeed()));
-        m_intakeRotation.setAngle(superStructureData.getIntakeAngle());
+        m_intakeRotation.setAngle(javafxAngle);
         m_intakeWheelRotation.setAngle(m_intakeRotation.getAngle());
         m_hanger.setFill(Utils.getMotorColor(superStructureData.getHangerSpeed()));
         m_shooter.setFill(Utils.getMotorColor(superStructureData.getShooterSpeed()));

--- a/y2022/RapidReactDashboard/src/main/java/com/gos/rapidreact/shuffleboard/super_structure/SuperStructureStandaloneMain.java
+++ b/y2022/RapidReactDashboard/src/main/java/com/gos/rapidreact/shuffleboard/super_structure/SuperStructureStandaloneMain.java
@@ -3,13 +3,23 @@ package com.gos.rapidreact.shuffleboard.super_structure;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Scene;
+import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.BorderStroke;
+import javafx.scene.layout.BorderStrokeStyle;
+import javafx.scene.layout.BorderWidths;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 import java.io.IOException;
+import java.util.Map;
 
-@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
+@SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity", "PMD.TooManyFields"})
 public class SuperStructureStandaloneMain {
     private final SuperStructureWidget m_controller;
 
@@ -25,8 +35,38 @@ public class SuperStructureStandaloneMain {
     private boolean m_superStructureLowerVerticalConveyorIndexingSensor;
     private boolean m_superStructureUpperVerticalConveyorIndexingSensor;
 
+
+    private final Label m_superStructureIntakeAngleLabel = new Label("Q/A -> superStructureIntakeAngle");
+    private final Label m_superStructureIntakeSpeedLabel = new Label("W/S -> superStructureIntakeSpeed");
+    private final Label m_superStructureRollerSpeedLabel = new Label("E/D -> superStructureRollerSpeed");
+    private final Label m_superStructureHangerSpeedLabel = new Label("R/F -> superStructureHangerSpeed");
+    private final Label m_superStructureHangerHeightLabel = new Label("T/G -> superStructureHangerHeight");
+    private final Label m_superStructureHorizontalConveyorSpeedLabel = new Label("Y/H -> superStructureHorizontalConveyorSpeed");
+    private final Label m_superStructureVerticalConveyorSpeedLabel = new Label("U/J -> superStructureVerticalConveyorSpeed");
+    private final Label m_superStructureShooterSpeedLabel = new Label("I/K -> superStructureShooterSpeed");
+    private final Label m_superStructureIntakeIndexingSensorLabel = new Label("DIGIT0 -> superStructureIntakeIndexingSensor");
+    private final Label m_superStructureLowerVerticalConveyorIndexingSensorLabel = new Label("DIGIT1 -> superStructureLowerVerticalConveyorIndexingSensor");
+    private final Label m_superStructureUpperVerticalConveyorIndexingSensorLabel = new Label("DIGIT2 -> superStructureUpperVerticalConveyorIndexingSensor");
+
     public SuperStructureStandaloneMain(Scene scene, SuperStructureWidget robotController) {
         m_controller = robotController;
+
+        VBox labelPane = new VBox();
+        labelPane.setBorder(new Border(new BorderStroke(Color.BLACK,
+            BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT)));
+
+        labelPane.getChildren().add(m_superStructureIntakeAngleLabel);
+        labelPane.getChildren().add(m_superStructureIntakeSpeedLabel);
+        labelPane.getChildren().add(m_superStructureRollerSpeedLabel);
+        labelPane.getChildren().add(m_superStructureHangerSpeedLabel);
+        labelPane.getChildren().add(m_superStructureHangerHeightLabel);
+        labelPane.getChildren().add(m_superStructureHorizontalConveyorSpeedLabel);
+        labelPane.getChildren().add(m_superStructureVerticalConveyorSpeedLabel);
+        labelPane.getChildren().add(m_superStructureShooterSpeedLabel);
+        labelPane.getChildren().add(m_superStructureIntakeIndexingSensorLabel);
+        labelPane.getChildren().add(m_superStructureLowerVerticalConveyorIndexingSensorLabel);
+        labelPane.getChildren().add(m_superStructureUpperVerticalConveyorIndexingSensorLabel);
+        ((BorderPane) scene.getRoot()).setBottom(labelPane);
 
         scene.setOnKeyPressed(event -> {
             KeyCode code = event.getCode();
@@ -35,63 +75,82 @@ public class SuperStructureStandaloneMain {
             // SuperStructure
             case Q:
                 m_superStructureIntakeAngle -= 2;
+                m_superStructureIntakeAngleLabel.setTextFill(Color.GREEN);
                 break;
             case A:
                 m_superStructureIntakeAngle += 2;
+                m_superStructureIntakeAngleLabel.setTextFill(Color.GREEN);
                 break;
             case W:
                 m_superStructureIntakeSpeed = 0.25;
+                m_superStructureIntakeSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case S:
                 m_superStructureIntakeSpeed = -0.25;
+                m_superStructureIntakeSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case E:
                 m_superStructureRollerSpeed = 0.25;
+                m_superStructureRollerSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case D:
                 m_superStructureRollerSpeed = -0.25;
+                m_superStructureRollerSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case R:
                 m_superStructureHangerSpeed = 0.25;
+                m_superStructureHangerSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case F:
                 m_superStructureHangerSpeed = -0.25;
+                m_superStructureHangerSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case T:
                 m_superStructureHangerHeight -= 2;
+                m_superStructureHangerHeightLabel.setTextFill(Color.GREEN);
                 break;
             case G:
                 m_superStructureHangerHeight += 2;
+                m_superStructureHangerHeightLabel.setTextFill(Color.GREEN);
                 break;
             case Y:
                 m_superStructureHorizontalConveyorSpeed = 0.25;
+                m_superStructureHorizontalConveyorSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case H:
                 m_superStructureHorizontalConveyorSpeed = -0.25;
+                m_superStructureHorizontalConveyorSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case U:
                 m_superStructureVerticalConveyorSpeed = 0.25;
+                m_superStructureVerticalConveyorSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case J:
                 m_superStructureVerticalConveyorSpeed = -0.25;
+                m_superStructureVerticalConveyorSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case I:
                 m_superStructureShooterSpeed = 0.25;
+                m_superStructureShooterSpeedLabel.setTextFill(Color.GREEN);
                 break;
             case K:
                 m_superStructureShooterSpeed = -0.25;
+                m_superStructureShooterSpeedLabel.setTextFill(Color.GREEN);
                 break;
 
             case DIGIT0:
                 m_superStructureIntakeIndexingSensor = true;
+                m_superStructureIntakeIndexingSensorLabel.setTextFill(Color.GREEN);
                 break;
 
             case DIGIT1:
                 m_superStructureLowerVerticalConveyorIndexingSensor = true;
+                m_superStructureLowerVerticalConveyorIndexingSensorLabel.setTextFill(Color.GREEN);
                 break;
 
             case DIGIT2:
                 m_superStructureUpperVerticalConveyorIndexingSensor = true;
+                m_superStructureUpperVerticalConveyorIndexingSensorLabel.setTextFill(Color.GREEN);
                 break;
 
             default:
@@ -106,43 +165,58 @@ public class SuperStructureStandaloneMain {
             switch (code) {
 
             // SuperStructure
-
+            case Q:
+            case A:
+                m_superStructureIntakeAngleLabel.setTextFill(Color.BLACK);
+                break;
             case W:
             case S:
                 m_superStructureIntakeSpeed = 0;
+                m_superStructureIntakeSpeedLabel.setTextFill(Color.BLACK);
                 break;
             case E:
             case D:
                 m_superStructureRollerSpeed = 0;
+                m_superStructureRollerSpeedLabel.setTextFill(Color.BLACK);
                 break;
             case R:
             case F:
                 m_superStructureHangerSpeed = 0;
+                m_superStructureHangerSpeedLabel.setTextFill(Color.BLACK);
                 break;
-
+            case T:
+            case G:
+                m_superStructureHangerHeightLabel.setTextFill(Color.BLACK);
+                break;
             case Y:
             case H:
                 m_superStructureHorizontalConveyorSpeed = 0;
+                m_superStructureHorizontalConveyorSpeedLabel.setTextFill(Color.BLACK);
                 break;
             case U:
             case J:
                 m_superStructureVerticalConveyorSpeed = 0;
+                m_superStructureVerticalConveyorSpeedLabel.setTextFill(Color.BLACK);
                 break;
             case I:
             case K:
                 m_superStructureShooterSpeed = 0;
+                m_superStructureShooterSpeedLabel.setTextFill(Color.BLACK);
                 break;
 
             case DIGIT0:
                 m_superStructureIntakeIndexingSensor = false;
+                m_superStructureIntakeIndexingSensorLabel.setTextFill(Color.BLACK);
                 break;
 
             case DIGIT1:
                 m_superStructureLowerVerticalConveyorIndexingSensor = false;
+                m_superStructureLowerVerticalConveyorIndexingSensorLabel.setTextFill(Color.BLACK);
                 break;
 
             case DIGIT2:
                 m_superStructureUpperVerticalConveyorIndexingSensor = false;
+                m_superStructureUpperVerticalConveyorIndexingSensorLabel.setTextFill(Color.BLACK);
                 break;
             default:
                 break;
@@ -168,6 +242,11 @@ public class SuperStructureStandaloneMain {
                 m_superStructureLowerVerticalConveyorIndexingSensor,
                 m_superStructureUpperVerticalConveyorIndexingSensor
             );
+
+            final SuperStructureData oldData =  m_controller.dataProperty().getValue();
+            Map<String, Object> changes = data.changesFrom(oldData);
+            System.out.println(changes);
+
             m_controller.dataProperty().setValue(data);
         } catch (ClassCastException ignored) {
             // don't worry about it

--- a/y2022/RapidReactDashboard/src/main/resources/com/gos/rapidreact/shuffleboard/super_structure/super_structure_widget.fxml
+++ b/y2022/RapidReactDashboard/src/main/resources/com/gos/rapidreact/shuffleboard/super_structure/super_structure_widget.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.layout.BorderPane?>
-<BorderPane fx:id="m_root" prefHeight="100" prefWidth="100"
+<BorderPane fx:id="m_root" prefHeight="350" prefWidth="250"
             xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="com.gos.rapidreact.shuffleboard.super_structure.SuperStructureWidget">
     <center>


### PR DESCRIPTION
- CI updates to check the new dashboard generation is consistent
- Needed to add some extra PMD suppression things to generation, which is why other dashboards were touched
- Added `unused_deps` step to the linting pipeline. Doesn't do automatically do or check anything, but will generate the commands necessary to fixup
- Added bazel build scripts for the 2022 robot
- Beefed up the dashboard tester generation to include labels for what key strokes simulate which field