### PR TITLE
Refactor properties to simplify API

### DIFF
--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/auton_modes/TrajectoryFactory.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/auton_modes/TrajectoryFactory.java
@@ -18,8 +18,8 @@ import java.util.List;
 public final class TrajectoryFactory {
 
     public static final class AutoConstants {
-        public static final PropertyManager.IProperty<Double> MAX_SPEED_METERS_PER_SECOND = PropertyManager.createDoubleProperty(false, "Trajectory.MaxVelocity", Units.inchesToMeters(12));
-        public static final PropertyManager.IProperty<Double> MAX_ACCELERATION_METERS_PER_SECOND_SQUARED = PropertyManager.createDoubleProperty(false, "Trajectory.MaxAcceleration", Units.inchesToMeters(12));
+        public static final GosDoubleProperty MAX_SPEED_METERS_PER_SECOND = new GosDoubleProperty(false, "Trajectory.MaxVelocity", Units.inchesToMeters(12));
+        public static final GosDoubleProperty MAX_ACCELERATION_METERS_PER_SECOND_SQUARED = new GosDoubleProperty(false, "Trajectory.MaxAcceleration", Units.inchesToMeters(12));
 
     }
 

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/auton_modes/TrajectoryFactory.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/auton_modes/TrajectoryFactory.java
@@ -1,7 +1,9 @@
 package com.gos.codelabs.pid.auton_modes;
 
-import com.gos.lib.properties.PropertyManager;
 import com.gos.codelabs.pid.Constants;
+import com.gos.codelabs.pid.commands.auton.DriveTrajectoryCommand;
+import com.gos.codelabs.pid.subsystems.ChassisSubsystem;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -9,8 +11,6 @@ import edu.wpi.first.math.trajectory.TrajectoryConfig;
 import edu.wpi.first.math.trajectory.TrajectoryGenerator;
 import edu.wpi.first.math.trajectory.constraint.DifferentialDriveVoltageConstraint;
 import edu.wpi.first.math.util.Units;
-import com.gos.codelabs.pid.commands.auton.DriveTrajectoryCommand;
-import com.gos.codelabs.pid.subsystems.ChassisSubsystem;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
 import java.util.List;

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindChassisTurningCompensationCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindChassisTurningCompensationCommand.java
@@ -6,7 +6,7 @@ import com.gos.lib.properties.PropertyManager;
 
 
 public class FindChassisTurningCompensationCommand extends CommandBase {
-    private static final PropertyManager.IProperty<Double> CHASSIS_SPEED = PropertyManager.createDoubleProperty(false, "Tuning.Chassis.TurningComp", 0);
+    private static final GosDoubleProperty CHASSIS_SPEED = new GosDoubleProperty(false, "Tuning.Chassis.TurningComp", 0);
 
     private final ChassisSubsystem m_chassisSubsystem;
 

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindChassisTurningCompensationCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindChassisTurningCompensationCommand.java
@@ -1,8 +1,8 @@
 package com.gos.codelabs.pid.commands.tuning;
 
 import com.gos.codelabs.pid.subsystems.ChassisSubsystem;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 
 
 public class FindChassisTurningCompensationCommand extends CommandBase {

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindShooterFFGainCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindShooterFFGainCommand.java
@@ -1,8 +1,8 @@
 package com.gos.codelabs.pid.commands.tuning;
 
 import com.gos.codelabs.pid.subsystems.ShooterSubsystem;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 
 public class FindShooterFFGainCommand extends CommandBase {
 

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindShooterFFGainCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/FindShooterFFGainCommand.java
@@ -6,7 +6,7 @@ import com.gos.lib.properties.PropertyManager;
 
 public class FindShooterFFGainCommand extends CommandBase {
 
-    private static final PropertyManager.IProperty<Double> SHOOTER_SPEED = PropertyManager.createDoubleProperty(false, "Tuning.Shooter.FFSpeed", 0);
+    private static final GosDoubleProperty SHOOTER_SPEED = new GosDoubleProperty(false, "Tuning.Shooter.FFSpeed", 0);
     private final ShooterSubsystem m_shooter;
 
     public FindShooterFFGainCommand(ShooterSubsystem shooter) {

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneChassisVelocityCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneChassisVelocityCommand.java
@@ -5,7 +5,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import com.gos.lib.properties.PropertyManager;
 
 public class TuneChassisVelocityCommand extends CommandBase {
-    private static final PropertyManager.IProperty<Double> CHASSIS_VELOCITY = PropertyManager.createDoubleProperty(false, "Tuning.Chassis.Velocity", 0);
+    private static final GosDoubleProperty CHASSIS_VELOCITY = new GosDoubleProperty(false, "Tuning.Chassis.Velocity", 0);
 
     private final ChassisSubsystem m_chassisSubsystem;
 

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneChassisVelocityCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneChassisVelocityCommand.java
@@ -1,8 +1,8 @@
 package com.gos.codelabs.pid.commands.tuning;
 
 import com.gos.codelabs.pid.subsystems.ChassisSubsystem;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 
 public class TuneChassisVelocityCommand extends CommandBase {
     private static final GosDoubleProperty CHASSIS_VELOCITY = new GosDoubleProperty(false, "Tuning.Chassis.Velocity", 0);

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneShooterRpmCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneShooterRpmCommand.java
@@ -1,8 +1,8 @@
 package com.gos.codelabs.pid.commands.tuning;
 
 import com.gos.codelabs.pid.subsystems.ShooterSubsystem;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 
 
 public class TuneShooterRpmCommand extends CommandBase {

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneShooterRpmCommand.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/commands/tuning/TuneShooterRpmCommand.java
@@ -6,7 +6,7 @@ import com.gos.lib.properties.PropertyManager;
 
 
 public class TuneShooterRpmCommand extends CommandBase {
-    private static final PropertyManager.IProperty<Double> SHOOTER_RPM = PropertyManager.createDoubleProperty(false, "Tuning.Shooter.RPM", 1500);
+    private static final GosDoubleProperty SHOOTER_RPM = new GosDoubleProperty(false, "Tuning.Shooter.RPM", 1500);
 
     private final ShooterSubsystem m_spinningWheelSubsystem;
 

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/subsystems/ElevatorSubsystem.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/subsystems/ElevatorSubsystem.java
@@ -1,7 +1,7 @@
 package com.gos.codelabs.pid.subsystems;
 
 import com.gos.codelabs.pid.Constants;
-import com.gos.lib.properties.PropertyManager;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxPIDController;
 import com.revrobotics.CANSparkMaxLowLevel;

--- a/codelabs/pid/src/main/java/com/gos/codelabs/pid/subsystems/ElevatorSubsystem.java
+++ b/codelabs/pid/src/main/java/com/gos/codelabs/pid/subsystems/ElevatorSubsystem.java
@@ -21,7 +21,7 @@ import org.snobotv2.sim_wrappers.ElevatorSimWrapper;
 import org.snobotv2.sim_wrappers.ISimWrapper;
 
 public class ElevatorSubsystem extends SubsystemBase {
-    public static final PropertyManager.IProperty<Double> GRAVITY_COMPENSATION = PropertyManager.createDoubleProperty(false, "Elevator.GravityCompensationSpeed", 0);
+    public static final GosDoubleProperty GRAVITY_COMPENSATION = new GosDoubleProperty(false, "Elevator.GravityCompensationSpeed", 0);
 
     public static final double ALLOWABLE_POSITION_ERROR = .25;
 

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosBooleanProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosBooleanProperty.java
@@ -1,0 +1,23 @@
+package com.gos.lib.properties;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class GosBooleanProperty {
+    private final PropertyManager.IProperty<Boolean> m_impl;
+
+    public GosBooleanProperty(boolean isConstant, String key, boolean defaultValue) {
+        if (isConstant) {
+            m_impl = new PropertyManager.ConstantProperty<>(key, defaultValue);
+        } else {
+            m_impl = new PropertyManager.BaseProperty<>(key, defaultValue, Preferences::setBoolean, Preferences::getBoolean);
+        }
+    }
+
+    public boolean getValue() {
+        return m_impl.getValue();
+    }
+
+    public String getName() {
+        return m_impl.getName();
+    }
+}

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosDoubleProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosDoubleProperty.java
@@ -1,0 +1,23 @@
+package com.gos.lib.properties;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class GosDoubleProperty {
+    private final PropertyManager.IProperty<Double> m_impl;
+
+    public GosDoubleProperty(boolean isConstant, String key, double defaultValue) {
+        if (isConstant) {
+            m_impl = new PropertyManager.ConstantProperty<>(key, defaultValue);
+        } else {
+            m_impl = new PropertyManager.BaseProperty<>(key, defaultValue, Preferences::setDouble, Preferences::getDouble);
+        }
+    }
+
+    public double getValue() {
+        return m_impl.getValue();
+    }
+
+    public String getName() {
+        return m_impl.getName();
+    }
+}

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosIntProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosIntProperty.java
@@ -1,0 +1,23 @@
+package com.gos.lib.properties;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class GosIntProperty {
+    private final PropertyManager.IProperty<Integer> m_impl;
+
+    public GosIntProperty(boolean isConstant, String key, int defaultValue) {
+        if (isConstant) {
+            m_impl = new PropertyManager.ConstantProperty<>(key, defaultValue);
+        } else {
+            m_impl = new PropertyManager.BaseProperty<>(key, defaultValue, Preferences::setInt, Preferences::getInt);
+        }
+    }
+
+    public int getValue() {
+        return m_impl.getValue();
+    }
+
+    public String getName() {
+        return m_impl.getName();
+    }
+}

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosStringProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/GosStringProperty.java
@@ -1,0 +1,23 @@
+package com.gos.lib.properties;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class GosStringProperty {
+    private final PropertyManager.IProperty<String> m_impl;
+
+    public GosStringProperty(boolean isConstant, String key, String defaultValue) {
+        if (isConstant) {
+            m_impl = new PropertyManager.ConstantProperty<>(key, defaultValue);
+        } else {
+            m_impl = new PropertyManager.BaseProperty<>(key, defaultValue, Preferences::setString, Preferences::getString);
+        }
+    }
+
+    public String getValue() {
+        return m_impl.getValue();
+    }
+
+    public String getName() {
+        return m_impl.getName();
+    }
+}

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/HeavyDoubleProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/HeavyDoubleProperty.java
@@ -12,10 +12,10 @@ import java.util.function.DoubleConsumer;
  */
 public class HeavyDoubleProperty {
     private final DoubleConsumer m_setter;
-    private final PropertyManager.IProperty<Double> m_property;
+    private final GosDoubleProperty m_property;
     private double m_lastValue;
 
-    public HeavyDoubleProperty(DoubleConsumer setter, PropertyManager.IProperty<Double> property) {
+    public HeavyDoubleProperty(DoubleConsumer setter, GosDoubleProperty property) {
         m_setter = setter;
         m_property = property;
         m_lastValue = property.getValue();

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/PidProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/PidProperty.java
@@ -38,13 +38,9 @@ public class PidProperty {
 
         private HeavyDoubleProperty createDoubleProperty(String propertyNameSuffix, double defaultValue, DoubleConsumer setter) {
             String propertyName = m_baseName + ".mm." + propertyNameSuffix;
-            PropertyManager.IProperty<Double> prop = PropertyManager.createDoubleProperty(m_isConstant, propertyName, defaultValue);
-            if (m_isConstant) {
-                return new HeavyDoubleProperty(setter, prop);
-            }
-            else {
-                return new HeavyDoubleProperty(setter, prop);
-            }
+            GosDoubleProperty prop = new GosDoubleProperty(m_isConstant, propertyName, defaultValue);
+
+            return new HeavyDoubleProperty(setter, prop);
         }
 
         protected Builder addP(double defaultValue, DoubleConsumer setter) {

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/PropertyManager.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/PropertyManager.java
@@ -57,7 +57,6 @@ public final class PropertyManager {
         }
     }
 
-    @Deprecated
     /* default */ interface IProperty<TypeT> {
         TypeT getValue();
 

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/PropertyManager.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/PropertyManager.java
@@ -57,17 +57,18 @@ public final class PropertyManager {
         }
     }
 
-    public interface IProperty<TypeT> {
+    @Deprecated
+    /* default */ interface IProperty<TypeT> {
         TypeT getValue();
 
         String getName();
     }
 
-    private static class ConstantProperty<TypeT> implements IProperty<TypeT> {
+    /* default */ static class ConstantProperty<TypeT> implements IProperty<TypeT> {
         private final TypeT m_value;
         private final String m_name;
 
-        private ConstantProperty(String key, TypeT value) {
+        /* default */ ConstantProperty(String key, TypeT value) {
             m_value = value;
             m_name = key;
 
@@ -88,14 +89,14 @@ public final class PropertyManager {
         }
     }
 
-    private static class BaseProperty<TypeT> implements IProperty<TypeT> {
+    /* default */ static class BaseProperty<TypeT> implements IProperty<TypeT> {
         private final String m_key;
         private final TypeT m_default;
         private final BiConsumer<String, TypeT> m_setter;
         private final BiFunction<String, TypeT, TypeT> m_getter;
         private final String m_constructionStackTrace;
 
-        private BaseProperty(String key, TypeT defaultValue, BiConsumer<String, TypeT> setter,
+        /* default */ BaseProperty(String key, TypeT defaultValue, BiConsumer<String, TypeT> setter,
                 BiFunction<String, TypeT, TypeT> getter) {
             m_key = key;
             m_default = defaultValue;
@@ -136,57 +137,5 @@ public final class PropertyManager {
         public String getName() {
             return m_key;
         }
-    }
-
-    private static class IntProperty extends BaseProperty<Integer> {
-        private IntProperty(String key, int defaultValue) {
-            super(key, defaultValue, Preferences::setInt, Preferences::getInt);
-        }
-    }
-
-    public static IProperty<Integer> createIntProperty(boolean isConstant, String key, int defaultValue) {
-        if (isConstant) {
-            return new ConstantProperty<>(key, defaultValue);
-        }
-        return new IntProperty(key, defaultValue);
-    }
-
-    private static class DoubleProperty extends BaseProperty<Double> {
-        private DoubleProperty(String key, double defaultValue) {
-            super(key, defaultValue, Preferences::setDouble, Preferences::getDouble);
-        }
-    }
-
-    public static IProperty<Double> createDoubleProperty(boolean isConstant, String key, double defaultValue) {
-        if (isConstant) {
-            return new ConstantProperty<>(key, defaultValue);
-        }
-        return new DoubleProperty(key, defaultValue);
-    }
-
-    private static class StringProperty extends BaseProperty<String> {
-        private StringProperty(String key, String defaultValue) {
-            super(key, defaultValue, Preferences::setString, Preferences::getString);
-        }
-    }
-
-    public static IProperty<String> createStringProperty(boolean isConstant, String key, String defaultValue) {
-        if (isConstant) {
-            return new ConstantProperty<>(key, defaultValue);
-        }
-        return new StringProperty(key, defaultValue);
-    }
-
-    private static class BooleanProperty extends BaseProperty<Boolean> {
-        private BooleanProperty(String key, boolean defaultValue) {
-            super(key, defaultValue, Preferences::setBoolean, Preferences::getBoolean);
-        }
-    }
-
-    public static IProperty<Boolean> createBooleanProperty(boolean isConstant, String key, boolean defaultValue) {
-        if (isConstant) {
-            return new ConstantProperty<>(key, defaultValue);
-        }
-        return new BooleanProperty(key, defaultValue);
     }
 }

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/TuneRPM.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/TuneRPM.java
@@ -1,14 +1,14 @@
 package com.gos.infinite_recharge.commands;
 
 import com.gos.infinite_recharge.Constants;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 import com.gos.infinite_recharge.subsystems.Shooter;
 
 
 public class TuneRPM extends CommandBase {
 
-    private static final PropertyManager.IProperty<Double> TUNE_RPM_PROP = PropertyManager.createDoubleProperty(false, "TuneRpm", Constants.DEFAULT_RPM);
+    private static final GosDoubleProperty TUNE_RPM_PROP = new GosDoubleProperty(false, "TuneRpm", Constants.DEFAULT_RPM);
     private final Shooter m_shooter;
 
     public TuneRPM(Shooter shooter) {

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/DriveDistance.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/DriveDistance.java
@@ -1,12 +1,12 @@
 package com.gos.infinite_recharge.commands.autonomous;
 
 import com.gos.infinite_recharge.subsystems.Chassis;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 
 public class DriveDistance extends CommandBase {
 
-    private static final PropertyManager.IProperty<Double> AUTO_KP = PropertyManager.createDoubleProperty(false, "DriveDistanceKp", 0.5);
+    private static final GosDoubleProperty AUTO_KP = new GosDoubleProperty(false, "DriveDistanceKp", 0.5);
 
     private final Chassis m_chassis;
     private final double m_distance;

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/GoToPosition.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/GoToPosition.java
@@ -1,8 +1,8 @@
 package com.gos.infinite_recharge.commands.autonomous;
 
 import com.gos.infinite_recharge.subsystems.Chassis;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import com.gos.lib.properties.PropertyManager;
 
 public class GoToPosition extends CommandBase {
 
@@ -20,8 +20,8 @@ public class GoToPosition extends CommandBase {
     private final double m_finalPositionX;
     private final double m_finalPositionY;
 
-    private static final PropertyManager.IProperty<Double> AUTO_KP = PropertyManager.createDoubleProperty(false, "DriveToPointDriveKp", 0.04);
-    private static final PropertyManager.IProperty<Double> AUTO_KP_ANGLE = PropertyManager.createDoubleProperty(false, "DriveToPointSteerKp",  0.25);
+    private static final GosDoubleProperty AUTO_KP = new GosDoubleProperty(false, "DriveToPointDriveKp", 0.04);
+    private static final GosDoubleProperty AUTO_KP_ANGLE = new GosDoubleProperty(false, "DriveToPointSteerKp",  0.25);
 
     public GoToPosition(Chassis chassis, double finalPositionX, double finalPositionY, double allowableError) {
         // Use requires() here to declare subsystem dependencies

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/TurnToAngle.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/TurnToAngle.java
@@ -2,18 +2,18 @@ package com.gos.infinite_recharge.commands.autonomous;
 
 import com.gos.infinite_recharge.Constants;
 import com.gos.infinite_recharge.subsystems.Chassis;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import com.gos.lib.DeadbandHelper;
-import com.gos.lib.properties.PropertyManager;
 
 public class TurnToAngle extends CommandBase {
 
-    private static final PropertyManager.IProperty<Double> AUTO_KP = PropertyManager.createDoubleProperty(false, "TurnToAngleKp",
+    private static final GosDoubleProperty AUTO_KP = new GosDoubleProperty(false, "TurnToAngleKp",
             0.02);
-    private static final PropertyManager.IProperty<Double> AUTO_KI = PropertyManager.createDoubleProperty(false, "TurnToAngleKi",
+    private static final GosDoubleProperty AUTO_KI = new GosDoubleProperty(false, "TurnToAngleKi",
             0);
-    private static final PropertyManager.IProperty<Double> AUTO_KD = PropertyManager.createDoubleProperty(false, "TurnToAngleKd",
+    private static final GosDoubleProperty AUTO_KD = new GosDoubleProperty(false, "TurnToAngleKd",
             0);
 
     private final Chassis m_chassis;

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/TurnToAngleProfiled.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/commands/autonomous/TurnToAngleProfiled.java
@@ -2,22 +2,22 @@ package com.gos.infinite_recharge.commands.autonomous;
 
 import com.gos.infinite_recharge.Constants;
 import com.gos.infinite_recharge.subsystems.Chassis;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj2.command.ProfiledPIDCommand;
-import com.gos.lib.properties.PropertyManager;
 
 public class TurnToAngleProfiled extends ProfiledPIDCommand {
 
-    private static final PropertyManager.IProperty<Double> AUTO_KP = PropertyManager.createDoubleProperty(
+    private static final GosDoubleProperty AUTO_KP = new GosDoubleProperty(
             true, "TurnToAngleProfiledKp", 0.05);
-    private static final PropertyManager.IProperty<Double> AUTO_KI = PropertyManager.createDoubleProperty(
+    private static final GosDoubleProperty AUTO_KI = new GosDoubleProperty(
         true, "TurnToAngleProfiledKi", 0.05);
-    private static final PropertyManager.IProperty<Double> AUTO_KD = PropertyManager.createDoubleProperty(
+    private static final GosDoubleProperty AUTO_KD = new GosDoubleProperty(
         true, "TurnToAngleProfiledKd", 0.05);
-    private static final PropertyManager.IProperty<Double> MAX_TURN_RATE_DEG_PER_SEC = PropertyManager.createDoubleProperty(
+    private static final GosDoubleProperty MAX_TURN_RATE_DEG_PER_SEC = new GosDoubleProperty(
         true, "MaxTurnRateDegPerSec", Constants.MAX_TURN_RATE_DEG_PER_S);
-    private static final PropertyManager.IProperty<Double> MAX_TURN_ACCELERATION_DEG_PER_SEC_SQUARED = PropertyManager.createDoubleProperty(
+    private static final GosDoubleProperty MAX_TURN_ACCELERATION_DEG_PER_SEC_SQUARED = new GosDoubleProperty(
         true, "MaxTurnAccelerationDegPerSecSquared", Constants.MAX_TURN_ACCELERATION_DEG_PER_S_SQUARED);
 
     // private final Chassis m_chassis;

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/subsystems/Limelight.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/subsystems/Limelight.java
@@ -1,6 +1,7 @@
 package com.gos.infinite_recharge.subsystems;
 
 import com.gos.infinite_recharge.Constants;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.lib.sensors.LidarLite;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -11,7 +12,6 @@ import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInWidgets;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import com.gos.lib.properties.PropertyManager;
 
 /**
  * Add your docs here.
@@ -20,31 +20,31 @@ import com.gos.lib.properties.PropertyManager;
 public class Limelight extends SubsystemBase {
 
     /// how hard to turn toward the target
-    private static final PropertyManager.IProperty<Double> STEER_KP_PROPERTY = PropertyManager.createDoubleProperty(false,
+    private static final GosDoubleProperty STEER_KP_PROPERTY = new GosDoubleProperty(false,
             "LimelightSteerK", 0.05);
 
-    private static final PropertyManager.IProperty<Double> STEER_KI_PROPERTY = PropertyManager.createDoubleProperty(false,
+    private static final GosDoubleProperty STEER_KI_PROPERTY = new GosDoubleProperty(false,
             "LimelightSteerKI", 0.0);
 
-    private static final PropertyManager.IProperty<Double> STEER_KD_PROPERTY = PropertyManager.createDoubleProperty(false,
+    private static final GosDoubleProperty STEER_KD_PROPERTY = new GosDoubleProperty(false,
             "LimelightSteerKD", 0.0);
 
     // how hard to drive fwd toward the target
-    private static final PropertyManager.IProperty<Double> DRIVE_K = PropertyManager.createDoubleProperty(false,
+    private static final GosDoubleProperty DRIVE_K = new GosDoubleProperty(false,
             "LimelightDriveK", 0.3);
 
     // Area of the target when the robot reaches the wall
-    private static final PropertyManager.IProperty<Double> DESIRED_TARGET_AREA = PropertyManager.createDoubleProperty(false,
+    private static final GosDoubleProperty DESIRED_TARGET_AREA = new GosDoubleProperty(false,
             "LimelightTargetArea", 13.0);
 
     // Simple speed limit so we don't drive too fast
-    private static final PropertyManager.IProperty<Double> MAX_DRIVE = PropertyManager.createDoubleProperty(false,
+    private static final GosDoubleProperty MAX_DRIVE = new GosDoubleProperty(false,
             "LimelihtMaxDrive", 0.3);
 
     // Measured from middle of Limelight to middle of high target
-    private static final PropertyManager.IProperty<Double> CAMERA_HEIGHT_OFFSET = PropertyManager.createDoubleProperty(true,
+    private static final GosDoubleProperty CAMERA_HEIGHT_OFFSET = new GosDoubleProperty(true,
             "LimelightHeightOffset", 60.0);
-    private static final PropertyManager.IProperty<Double> CAMERA_ANGLE_OFFSET = PropertyManager.createDoubleProperty(true,
+    private static final GosDoubleProperty CAMERA_ANGLE_OFFSET = new GosDoubleProperty(true,
             "LimelightAngleOffset", 20.0);
 
     private static final double ALLOWABLE_ERROR = 2;

--- a/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/subsystems/Shooter.java
+++ b/old_robots/y2020/2020InfiniteRecharge/src/main/java/com/gos/infinite_recharge/subsystems/Shooter.java
@@ -1,6 +1,7 @@
 package com.gos.infinite_recharge.subsystems;
 
 import com.gos.infinite_recharge.Constants;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxPIDController;
 import com.revrobotics.SparkMaxRelativeEncoder;
@@ -22,7 +23,6 @@ import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj.simulation.FlywheelSim;
 import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import com.gos.lib.properties.PropertyManager;
 
 public class Shooter extends SubsystemBase {
 
@@ -44,8 +44,8 @@ public class Shooter extends SubsystemBase {
 
     private final NetworkTable m_customNetworkTable;
 
-    private final PropertyManager.IProperty<Double> m_dashboardKp;
-    private final PropertyManager.IProperty<Double> m_dashboardKff;
+    private final GosDoubleProperty m_dashboardKp;
+    private final GosDoubleProperty m_dashboardKff;
 
     private final NetworkTableEntry m_isAtShooterSpeedEntry;
 
@@ -60,8 +60,8 @@ public class Shooter extends SubsystemBase {
         m_master.restoreFactoryDefaults();
         m_follower.restoreFactoryDefaults();
 
-        m_dashboardKp = PropertyManager.createDoubleProperty(false, "shooter_kp", SHOOTER_KP);
-        m_dashboardKff = PropertyManager.createDoubleProperty(false, "shooter_kff", SHOOTER_KFF);
+        m_dashboardKp = new GosDoubleProperty(false, "shooter_kp", SHOOTER_KP);
+        m_dashboardKff = new GosDoubleProperty(false, "shooter_kff", SHOOTER_KFF);
 
         m_limelight = limelight;
 

--- a/y2022/MEPI/src/main/java/com/scra/mepi/rapid_react/commands/ShooterPIDCommand.java
+++ b/y2022/MEPI/src/main/java/com/scra/mepi/rapid_react/commands/ShooterPIDCommand.java
@@ -4,7 +4,7 @@
 
 package com.scra.mepi.rapid_react.commands;
 
-import com.gos.lib.properties.PropertyManager;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.scra.mepi.rapid_react.subsystems.ShooterSubsytem;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
@@ -14,7 +14,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 public class ShooterPIDCommand extends CommandBase {
     private final ShooterSubsytem m_shooterSubsystem;
 
-    private final PropertyManager.IProperty<Double> m_tunableShooterGoal = PropertyManager.createDoubleProperty(false, "Shooter Goal", 1000);
+    private final GosDoubleProperty m_tunableShooterGoal = new GosDoubleProperty(false, "Shooter Goal", 1000);
 
     /**
      * Creates a new ExampleCommand.

--- a/y2022/MEPI/src/main/java/com/scra/mepi/rapid_react/subsystems/ShooterSubsytem.java
+++ b/y2022/MEPI/src/main/java/com/scra/mepi/rapid_react/subsystems/ShooterSubsytem.java
@@ -4,8 +4,8 @@
 
 package com.scra.mepi.rapid_react.subsystems;
 
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.lib.properties.PidProperty;
-import com.gos.lib.properties.PropertyManager;
 import com.gos.lib.rev.RevPidPropertyBuilder;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
@@ -41,8 +41,7 @@ public class ShooterSubsytem extends SubsystemBase {
     private final RelativeEncoder m_encoder;
     private final SparkMaxPIDController m_pidController;
     private final PidProperty m_pidProperties;
-    private final PropertyManager.IProperty<Double> m_tunableAllowableError =
-        PropertyManager.createDoubleProperty(false, "Shooter(AllowableError))", 50);
+    private final GosDoubleProperty m_tunableAllowableError = new GosDoubleProperty(false, "Shooter(AllowableError))", 50);
 
     // Simulation
     private ISimWrapper m_shooterSimulator;

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/TeleopArcadeChassisCommand.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/TeleopArcadeChassisCommand.java
@@ -1,14 +1,14 @@
 package com.gos.rapidreact.commands;
 
-import com.gos.lib.properties.PropertyManager;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.rapidreact.subsystems.ChassisSubsystem;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
 
 public class TeleopArcadeChassisCommand extends CommandBase {
-    private static final PropertyManager.IProperty<Double> SLOW_MULTIPLIER = PropertyManager.createDoubleProperty(false, "TeleDriveSlowMult", 0.5);
-    private static final PropertyManager.IProperty<Double> TURN_SCALING_MULTIPLIER = PropertyManager.createDoubleProperty(false, "TeleTurnScaling", 0.8);
+    private static final GosDoubleProperty SLOW_MULTIPLIER = new GosDoubleProperty(false, "TeleDriveSlowMult", 0.5);
+    private static final GosDoubleProperty TURN_SCALING_MULTIPLIER = new GosDoubleProperty(false, "TeleTurnScaling", 0.8);
     private final ChassisSubsystem m_chassis;
     private final XboxController m_joystick;
 

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/tuning/TuneShooterGoalRPMCommand.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/tuning/TuneShooterGoalRPMCommand.java
@@ -1,13 +1,13 @@
 package com.gos.rapidreact.commands.tuning;
 
-import com.gos.lib.properties.PropertyManager;
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import com.gos.rapidreact.subsystems.ShooterSubsystem;
 
 
 public class TuneShooterGoalRPMCommand extends CommandBase {
     private final ShooterSubsystem m_shooter;
-    private static final PropertyManager.IProperty<Double> SHOOTER_GOAL = PropertyManager.createDoubleProperty(false, "Tune Shooter RPM Goal", 0);
+    private static final GosDoubleProperty SHOOTER_GOAL = new GosDoubleProperty(false, "Tune Shooter RPM Goal", 0);
 
     public TuneShooterGoalRPMCommand(ShooterSubsystem shooterSubsystem) {
         this.m_shooter = shooterSubsystem;

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/tuning/TuneShooterMotorSpeedCommand.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/tuning/TuneShooterMotorSpeedCommand.java
@@ -1,14 +1,14 @@
 package com.gos.rapidreact.commands.tuning;
 
+import com.gos.lib.properties.GosDoubleProperty;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import com.gos.rapidreact.subsystems.ShooterSubsystem;
-import com.gos.lib.properties.PropertyManager;
 
 
 public class TuneShooterMotorSpeedCommand extends CommandBase {
     private final ShooterSubsystem m_shooter;
 
-    public static final PropertyManager.IProperty<Double> SHOOTER_SPEED = PropertyManager.createDoubleProperty(false, "Tune Shooter Motor Speed", 0);
+    public static final GosDoubleProperty SHOOTER_SPEED = new GosDoubleProperty(false, "Tune Shooter Motor Speed", 0);
 
     public TuneShooterMotorSpeedCommand(ShooterSubsystem shooterSubsystem) {
         this.m_shooter = shooterSubsystem;

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/tuning/VelocityControlDrivingTuningCommand.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/commands/tuning/VelocityControlDrivingTuningCommand.java
@@ -1,6 +1,6 @@
 package com.gos.rapidreact.commands.tuning;
 
-import com.gos.lib.properties.PropertyManager;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.rapidreact.subsystems.ChassisSubsystem;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -8,8 +8,8 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 public class VelocityControlDrivingTuningCommand extends CommandBase {
 
     private final ChassisSubsystem m_chassis;
-    private static final PropertyManager.IProperty<Double> GOAL_VELOCITY_FPS = PropertyManager.createDoubleProperty(false, "Chassis Tune Velocity (ft/s)", 0);
-    private static final PropertyManager.IProperty<Double> GOAL_ACCELERATION = PropertyManager.createDoubleProperty(false, "Chassis Tune Acceleration", 0);
+    private static final GosDoubleProperty GOAL_VELOCITY_FPS = new GosDoubleProperty(false, "Chassis Tune Velocity (ft/s)", 0);
+    private static final GosDoubleProperty GOAL_ACCELERATION = new GosDoubleProperty(false, "Chassis Tune Acceleration", 0);
 
     public VelocityControlDrivingTuningCommand(ChassisSubsystem chassis) {
         this.m_chassis = chassis;

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/subsystems/ChassisSubsystem.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/subsystems/ChassisSubsystem.java
@@ -2,9 +2,9 @@ package com.gos.rapidreact.subsystems;
 
 
 import com.ctre.phoenix.sensors.WPI_PigeonIMU;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.lib.properties.HeavyDoubleProperty;
 import com.gos.lib.properties.PidProperty;
-import com.gos.lib.properties.PropertyManager;
 import com.gos.lib.properties.WpiPidPropertyBuilder;
 import com.gos.lib.properties.WpiProfiledPidPropertyBuilder;
 import com.gos.lib.rev.RevPidPropertyBuilder;
@@ -48,10 +48,10 @@ public class ChassisSubsystem extends SubsystemBase {
     private static final double GEAR_RATIO = 40.0 / 12.0 * 40.0 / 14.0;
     private static final double ENCODER_CONSTANT = (1.0 / GEAR_RATIO) * WHEEL_DIAMETER * Math.PI;
 
-    private static final PropertyManager.IProperty<Double> TO_XY_DISTANCE_SPEED = PropertyManager.createDoubleProperty(false, "To XY Dist Speed", 0);
-    public static final PropertyManager.IProperty<Double> TO_XY_MAX_DISTANCE = PropertyManager.createDoubleProperty(false, "To XY Max Dist", 4);
+    private static final GosDoubleProperty TO_XY_DISTANCE_SPEED = new GosDoubleProperty(false, "To XY Dist Speed", 0);
+    public static final GosDoubleProperty TO_XY_MAX_DISTANCE = new GosDoubleProperty(false, "To XY Max Dist", 4);
 
-    private static final PropertyManager.IProperty<Double> DRIVER_OL_RAMP_RATE = PropertyManager.createDoubleProperty(false, "OpenLoopRampRate", 0.5);
+    private static final GosDoubleProperty DRIVER_OL_RAMP_RATE = new GosDoubleProperty(false, "OpenLoopRampRate", 0.5);
 
     private final HeavyDoubleProperty m_openLoopRampRateProperty;
 

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/subsystems/CollectorSubsystem.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/subsystems/CollectorSubsystem.java
@@ -1,7 +1,7 @@
 package com.gos.rapidreact.subsystems;
 
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.lib.properties.PidProperty;
-import com.gos.lib.properties.PropertyManager;
 import com.gos.lib.rev.RevPidPropertyBuilder;
 import com.gos.rapidreact.Constants;
 import com.revrobotics.CANSparkMax;
@@ -28,7 +28,7 @@ public class CollectorSubsystem extends SubsystemBase {
     private static final double ROLLER_SPEED = 0.5;
     private static final double PIVOT_SPEED = .2;
     public static final double ALLOWABLE_ERROR_DEG = 1;
-    public static final PropertyManager.IProperty<Double> GRAVITY_OFFSET = PropertyManager.createDoubleProperty(false, "Gravity Offset", 0);
+    public static final GosDoubleProperty GRAVITY_OFFSET = new GosDoubleProperty(false, "Gravity Offset", 0);
     private static final double GEARING =  252.0;
     private static final double J_KG_METERS_SQUARED = 1;
     private static final double ARM_LENGTH_METERS = Units.inchesToMeters(16);

--- a/y2022/RapidReact/src/main/java/com/gos/rapidreact/subsystems/sim/LimelightSim.java
+++ b/y2022/RapidReact/src/main/java/com/gos/rapidreact/subsystems/sim/LimelightSim.java
@@ -1,6 +1,6 @@
 package com.gos.rapidreact.subsystems.sim;
 
-import com.gos.lib.properties.PropertyManager;
+import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.rapidreact.subsystems.IntakeLimelightSubsystem;
 import com.gos.rapidreact.subsystems.ShooterLimelightSubsystem;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -16,8 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LimelightSim {
-    private static final PropertyManager.IProperty<Double> CARGO_X = PropertyManager.createDoubleProperty(false, "Sim Limelight Cargo X", 0);
-    private static final PropertyManager.IProperty<Double> CARGO_Y = PropertyManager.createDoubleProperty(false, "Sim Limelight Cargo Y", 0);
+    private static final GosDoubleProperty CARGO_X = new GosDoubleProperty(false, "Sim Limelight Cargo X", 0);
+    private static final GosDoubleProperty CARGO_Y = new GosDoubleProperty(false, "Sim Limelight Cargo Y", 0);
 
     private static final double INTAKE_MAX_DISTANCE = Double.MAX_VALUE;
     private static final double SHOOTER_MAX_DISTANCE = Double.MAX_VALUE;


### PR DESCRIPTION
Moves the property implementations out of the `PropertyManager` class, and refactors it so you don't need the generics. API is now has a standard construction model instead of using factory functions.