### PR TITLE
[swerve] Bring in more of the rev swerve template + GOS modifications

### DIFF
--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/swerve/BUILD.bazel
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/swerve/BUILD.bazel
@@ -1,0 +1,11 @@
+load("//build_scripts/bazel:java_rules.bzl", "gos_java_library")
+
+gos_java_library(
+    name = "swerve",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bzlmodrio-allwpilib//libraries/java/ntcore",
+        "@bzlmodrio-allwpilib//libraries/java/wpimath",
+    ],
+)

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/swerve/SwerveDrivePublisher.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/swerve/SwerveDrivePublisher.java
@@ -1,4 +1,4 @@
-package com.gos.chargedup;
+package com.gos.lib.swerve;
 
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModuleState;

--- a/libraries/GirlsOfSteelLibRev/build.gradle
+++ b/libraries/GirlsOfSteelLibRev/build.gradle
@@ -10,6 +10,10 @@ dependencies {
     implementation wpi.java.deps.wpilib()
     implementation wpi.java.vendor.java()
     implementation project(":libraries:GirlsOfSteelLib")
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 
 test {

--- a/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/BUILD.bazel
+++ b/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//build_scripts/bazel:java_rules.bzl", "gos_java_library")
+
+gos_java_library(
+    name = "swerve",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/logging",
+        "//libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/pid",
+        "//libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/swerve",
+        "//libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/alerts",
+        "//libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/properties/pid",
+        "@bzlmodrio-allwpilib//libraries/java/ntcore",
+        "@bzlmodrio-allwpilib//libraries/java/wpilibj",
+        "@bzlmodrio-allwpilib//libraries/java/wpimath",
+        "@bzlmodrio-revlib//libraries/java/revlib-java",
+        "@maven//:org_snobotv2_snobot_sim_java",
+        "@maven//:org_snobotv2_snobot_swerve_sim",
+    ],
+)

--- a/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/RevSwerveChassis.java
+++ b/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/RevSwerveChassis.java
@@ -1,0 +1,260 @@
+package com.gos.lib.rev.swerve;
+
+import com.gos.lib.swerve.SwerveDrivePublisher;
+import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
+import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
+import edu.wpi.first.math.kinematics.SwerveModulePosition;
+import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.RobotBase;
+import org.snobotv2.module_wrappers.BaseGyroWrapper;
+import org.snobotv2.sim_wrappers.SwerveModuleSimWrapper;
+import org.snobotv2.sim_wrappers.SwerveSimWrapper;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+public class RevSwerveChassis {
+    private final double m_maxSpeedMetersPerSecond;
+    private final double m_maxAngularSpeed;
+
+    private final SwerveDriveKinematics m_kinematics;
+
+    // Create MAXSwerveModules
+    private final RevSwerveModule m_frontLeft;
+    private final RevSwerveModule m_frontRight;
+    private final RevSwerveModule m_backLeft;
+    private final RevSwerveModule m_backRight;
+
+    private final RevSwerveModule[] m_modules;
+
+    // The gyro sensor
+    private final Supplier<Rotation2d> m_gyroAngleSupplier;
+
+    // Odometry class for tracking robot pose
+    private final SwerveDriveOdometry m_odometry;
+    private final SwerveDrivePoseEstimator m_poseEstimator;
+
+    // Publish Telemetry
+    private final SwerveDrivePublisher m_swervePublisher;
+
+    // Simulation
+    private SwerveSimWrapper m_simulator;
+
+    /** Creates a new DriveSubsystem. */
+    public RevSwerveChassis(RevSwerveChassisConstants chassisConstants, Supplier<Rotation2d> gyroAngleSupplier, BaseGyroWrapper gyroSimulator) {
+        RevSwerveModuleConstants moduleConstants = new RevSwerveModuleConstants(chassisConstants.m_moduleDriveTeeth);
+
+        m_frontLeft = new RevSwerveModule(
+            "FL",
+            moduleConstants,
+            chassisConstants.m_frontLeftDrivingCanId,
+            chassisConstants.m_frontLeftTurningCanId,
+            RevSwerveChassisConstants.FRONT_LEFT_CHASSIS_ANGULAR_OFFSET);
+        m_frontRight = new RevSwerveModule(
+            "FR",
+            moduleConstants,
+            chassisConstants.m_frontRightDrivingCanId,
+            chassisConstants.m_frontRightTurningCanId,
+            RevSwerveChassisConstants.FRONT_RIGHT_CHASSIS_ANGULAR_OFFSET);
+        m_backLeft = new RevSwerveModule(
+            "BL",
+            moduleConstants,
+            chassisConstants.m_rearLeftDrivingCanId,
+            chassisConstants.m_rearLeftTurningCanId,
+            RevSwerveChassisConstants.BACK_LEFT_CHASSIS_ANGULAR_OFFSET);
+        m_backRight = new RevSwerveModule(
+            "BR",
+            moduleConstants,
+            chassisConstants.m_rearRightDrivingCanId,
+            chassisConstants.m_rearRightTurningCanId,
+            RevSwerveChassisConstants.BACK_RIGHT_CHASSIS_ANGULAR_OFFSET);
+        m_modules = new RevSwerveModule[]{m_frontLeft, m_frontRight, m_backLeft, m_backRight};
+
+        m_kinematics = new SwerveDriveKinematics(
+            new Translation2d(chassisConstants.m_wheelBase / 2, chassisConstants.m_trackWidth / 2),
+            new Translation2d(chassisConstants.m_wheelBase / 2, -chassisConstants.m_trackWidth / 2),
+            new Translation2d(-chassisConstants.m_wheelBase / 2, chassisConstants.m_trackWidth / 2),
+            new Translation2d(-chassisConstants.m_wheelBase / 2, -chassisConstants.m_trackWidth / 2)
+        );
+
+        m_gyroAngleSupplier = gyroAngleSupplier;
+
+        m_odometry = new SwerveDriveOdometry(
+            m_kinematics,
+            m_gyroAngleSupplier.get(),
+            getModulePositions());
+        m_poseEstimator = new SwerveDrivePoseEstimator(m_kinematics, m_gyroAngleSupplier.get(), getModulePositions(), new Pose2d());
+
+        m_swervePublisher = new SwerveDrivePublisher();
+
+        m_maxSpeedMetersPerSecond = chassisConstants.m_maxSpeedMetersPerSecond;
+        m_maxAngularSpeed = chassisConstants.m_maxAngularSpeed;
+
+        if (RobotBase.isSimulation()) {
+            List<SwerveModuleSimWrapper> moduleSims = List.of(
+                m_frontLeft.getSimWrapper(),
+                m_frontRight.getSimWrapper(),
+                m_backLeft.getSimWrapper(),
+                m_backRight.getSimWrapper());
+            m_simulator = new SwerveSimWrapper(chassisConstants.m_wheelBase, chassisConstants.m_trackWidth, 64.0, 1.0, moduleSims, gyroSimulator);
+        }
+    }
+
+    public void periodic() {
+        for (RevSwerveModule module : m_modules) {
+            module.periodic();
+        }
+
+        SwerveModulePosition[] modulePositions = getModulePositions();
+        Rotation2d rotation = m_gyroAngleSupplier.get();
+        m_odometry.update(rotation, modulePositions);
+        m_poseEstimator.update(rotation, modulePositions);
+
+        SwerveModuleState[] moduleStates = getModuleStates();
+        SwerveModuleState[] desiredStates = getModuleDesiredStates();
+        m_swervePublisher.setMeasuredStates(moduleStates);
+        m_swervePublisher.setDesiredStates(desiredStates);
+        m_swervePublisher.setRobotRotation(getEstimatedPosition().getRotation());
+    }
+
+    public void updateSimulator() {
+        m_simulator.update();
+    }
+
+    /**
+     * Returns the currently-estimated pose of the robot.
+     *
+     * @return The pose.
+     */
+    public Pose2d getEstimatedPosition() {
+        return m_poseEstimator.getEstimatedPosition();
+    }
+
+    public Pose2d getOdometryPosition() {
+        return m_odometry.getPoseMeters();
+    }
+
+    public void syncOdometryWithPoseEstimator() {
+        m_odometry.resetPosition(m_gyroAngleSupplier.get(), getModulePositions(), m_poseEstimator.getEstimatedPosition());
+    }
+
+    /**
+     * Resets the odometry to the specified pose.
+     *
+     * @param pose The pose to which to set the odometry.
+     */
+    public void resetOdometry(Pose2d pose) {
+        m_odometry.resetPosition(m_gyroAngleSupplier.get(), getModulePositions(), pose);
+        m_poseEstimator.resetPosition(m_gyroAngleSupplier.get(), getModulePositions(), pose);
+    }
+
+    /**
+     * Method to drive the robot using joystick info.
+     *
+     * @param xSpeed        Joystick speed of the robot in the x direction (forward).
+     * @param ySpeed        Joystick speed of the robot in the y direction (sideways).
+     * @param rot           Joystick angular rate of the robot.
+     * @param fieldRelative Whether the provided x and y speeds are relative to the
+     *                      field.
+     */
+    public void driveWithJoysticks(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
+        // Convert the commanded speeds into the correct units for the drivetrain
+        double xSpeedDelivered = xSpeed * m_maxSpeedMetersPerSecond;
+        double ySpeedDelivered = ySpeed * m_maxSpeedMetersPerSecond;
+        double rotDelivered = rot * m_maxAngularSpeed;
+
+        ChassisSpeeds desiredSpeed;
+        if (fieldRelative) {
+            desiredSpeed = ChassisSpeeds.fromFieldRelativeSpeeds(xSpeedDelivered, ySpeedDelivered, rotDelivered, m_gyroAngleSupplier.get());
+        } else {
+            desiredSpeed = new ChassisSpeeds(xSpeedDelivered, ySpeedDelivered, rotDelivered);
+        }
+        setChassisSpeeds(desiredSpeed);
+    }
+
+    /**
+     * Sets the wheels into an X formation to prevent movement.
+     */
+    public void setWheelsToXShape() {
+        m_frontLeft.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(45)));
+        m_frontRight.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(-45)));
+        m_backLeft.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(-45)));
+        m_backRight.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(45)));
+    }
+
+    /**
+     * Sets the swerve ModuleStates.
+     *
+     * @param desiredStates The desired SwerveModule states.
+     */
+    public void setModuleStates(SwerveModuleState... desiredStates) {
+        for (int i = 0; i < 4; i++) {
+            m_modules[i].setDesiredState(desiredStates[i]);
+        }
+    }
+
+    public final SwerveModulePosition[] getModulePositions() {
+        SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
+        for (int i = 0; i < 4; i += 1) {
+            modulePositions[i] = m_modules[i].getPosition();
+        }
+        return modulePositions;
+    }
+
+    public SwerveModuleState[] getModuleStates() {
+        SwerveModuleState[] modulePositions = new SwerveModuleState[4];
+        for (int i = 0; i < 4; i += 1) {
+            modulePositions[i] = m_modules[i].getState();
+        }
+        return modulePositions;
+    }
+
+    private SwerveModuleState[] getModuleDesiredStates() {
+        SwerveModuleState[] modulePositions = new SwerveModuleState[4];
+        for (int i = 0; i < 4; i += 1) {
+            modulePositions[i] = m_modules[i].getDesiredState();
+        }
+        return modulePositions;
+    }
+
+    public void stop() {
+        for (int i = 0; i < 4; i += 1) {
+            m_modules[i].setSpeedPercent(0, 0);
+        }
+    }
+
+    public void setChassisSpeedsPercent(double wheelPercent, double azimuthPercent) {
+        for (RevSwerveModule module: m_modules) {
+            module.setSpeedPercent(azimuthPercent, wheelPercent);
+        }
+    }
+
+    public void setModuleState(int moduleId, double degrees, double velocity) {
+        m_modules[moduleId].setDesiredState(new SwerveModuleState(velocity, Rotation2d.fromDegrees(degrees)));
+    }
+
+    public void setChassisSpeeds(ChassisSpeeds speeds) {
+        SwerveModuleState[] moduleStates = m_kinematics.toSwerveModuleStates(speeds);
+        SwerveDriveKinematics.desaturateWheelSpeeds(moduleStates, m_maxSpeedMetersPerSecond);
+        setModuleStates(moduleStates);
+    }
+
+    public ChassisSpeeds getChassisSpeed() {
+        return m_kinematics.toChassisSpeeds(getModuleStates());
+    }
+
+    public void clearStickyFaults() {
+        for (RevSwerveModule module: m_modules) {
+            module.clearStickyFaults();
+        }
+    }
+
+    public String getModuleName(int moduleId) {
+        return m_modules[moduleId].getName();
+    }
+}

--- a/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/RevSwerveChassisConstants.java
+++ b/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/RevSwerveChassisConstants.java
@@ -1,0 +1,84 @@
+package com.gos.lib.rev.swerve;
+
+@SuppressWarnings("PMD.DataClass")
+public class RevSwerveChassisConstants {
+    // Angular offsets of the modules relative to the chassis in radians
+    public static final double FRONT_LEFT_CHASSIS_ANGULAR_OFFSET = -Math.PI / 2;
+    public static final double FRONT_RIGHT_CHASSIS_ANGULAR_OFFSET = 0;
+    public static final double BACK_LEFT_CHASSIS_ANGULAR_OFFSET = Math.PI;
+    public static final double BACK_RIGHT_CHASSIS_ANGULAR_OFFSET = Math.PI / 2;
+
+    // SPARK MAX CAN IDs
+    public final int m_frontLeftDrivingCanId;
+    public final int m_rearLeftDrivingCanId;
+    public final int m_frontRightDrivingCanId;
+    public final int m_rearRightDrivingCanId;
+
+    public final int m_frontLeftTurningCanId;
+    public final int m_rearLeftTurningCanId;
+    public final int m_frontRightTurningCanId;
+    public final int m_rearRightTurningCanId;
+
+    public final double m_wheelBase;
+    public final double m_trackWidth;
+
+    public final RevSwerveModuleConstants.DriveMotorTeeth m_moduleDriveTeeth;
+    public final double m_maxSpeedMetersPerSecond;
+    public final double m_maxAngularSpeed;
+
+    /**
+     * Constants for configuring a REV Swerve Chassis
+     *
+     * @param frontLeftDrivingCanId The CAN id for the front left driving motor
+     * @param frontLeftTurningCanId The CAN id for the front left azimuth motor
+     * @param rearLeftDrivingCanId The CAN id for the rear left driving motor
+     * @param rearLeftTurningCanId The CAN id for the rear left azimuth motor
+     * @param frontRightDrivingCanId The CAN id for the front right driving motor
+     * @param frontRightTurningCanId The CAN id for the front right azimuth motor
+     * @param rearRightDrivingCanId The CAN id for the front right driving motor
+     * @param rearRightTurningCanId The CAN id for the front right azimuth motor
+     * @param moduleDriveTeeth The number of teeth in the driving motor pinion
+     * @param wheelBase Distance between front and back wheels on robot, in meters
+     * @param trackWidth Distance between centers of right and left wheels on robot, in meters
+     * @param maxSpeedMetersPerSecond The maximum translation speed of the drivetrain, in m / s
+     * @param maxAngularSpeed The maximum turning speed of the drivetrain, in rad / s
+     */
+    @SuppressWarnings("PMD.ExcessiveParameterList")
+    public RevSwerveChassisConstants(
+        int frontLeftDrivingCanId,
+        int frontLeftTurningCanId,
+
+        int rearLeftDrivingCanId,
+        int rearLeftTurningCanId,
+
+        int frontRightDrivingCanId,
+        int frontRightTurningCanId,
+
+        int rearRightDrivingCanId,
+        int rearRightTurningCanId,
+
+        RevSwerveModuleConstants.DriveMotorTeeth moduleDriveTeeth,
+
+        double wheelBase,
+        double trackWidth,
+
+        double maxSpeedMetersPerSecond,
+        double maxAngularSpeed) {
+        m_frontLeftDrivingCanId = frontLeftDrivingCanId;
+        m_rearLeftDrivingCanId = rearLeftDrivingCanId;
+        m_frontRightDrivingCanId = frontRightDrivingCanId;
+        m_rearRightDrivingCanId = rearRightDrivingCanId;
+
+        m_frontLeftTurningCanId = frontLeftTurningCanId;
+        m_rearLeftTurningCanId = rearLeftTurningCanId;
+        m_frontRightTurningCanId = frontRightTurningCanId;
+        m_rearRightTurningCanId = rearRightTurningCanId;
+
+        m_wheelBase = wheelBase;
+        m_trackWidth = trackWidth;
+
+        m_moduleDriveTeeth = moduleDriveTeeth;
+        m_maxSpeedMetersPerSecond = maxSpeedMetersPerSecond;
+        m_maxAngularSpeed = maxAngularSpeed;
+    }
+}

--- a/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/RevSwerveModuleConstants.java
+++ b/libraries/GirlsOfSteelLibRev/src/main/java/com/gos/lib/rev/swerve/RevSwerveModuleConstants.java
@@ -39,8 +39,22 @@ public final class RevSwerveModuleConstants {
         public static final double FREE_SPEED_RPM = 5676;
     }
 
-    public RevSwerveModuleConstants(int drivingMotorTeeth) {
-        m_drivingMotorReduction = (45.0 * 22) / (drivingMotorTeeth * 15);
+    public enum DriveMotorTeeth {
+        T12(12, Units.feetToMeters(13.51)),
+        T13(13, Units.feetToMeters(14.63)),
+        T14(14, Units.feetToMeters(15.76));
+
+        public final int m_teeth;
+        public final double m_theoreticalFreeSpeedMps;
+
+        DriveMotorTeeth(int teeth, double theoreticalFreeSpeedMps) {
+            m_teeth = teeth;
+            m_theoreticalFreeSpeedMps = theoreticalFreeSpeedMps;
+        }
+    }
+
+    public RevSwerveModuleConstants(DriveMotorTeeth teeth) {
+        m_drivingMotorReduction = (45.0 * 22) / (teeth.m_teeth * 15);
         m_driveWheelFreeSpeedRps = (DRIVING_MOTOR_FREE_SPEED_RPS * WHEEL_CIRCUMFERENCE_METERS)
             / m_drivingMotorReduction;
 

--- a/libraries/GirlsOfSteelLibRev/src/test/java/com/gos/lib/rev/swerve/RevSwerveModuleConstantsTest.java
+++ b/libraries/GirlsOfSteelLibRev/src/test/java/com/gos/lib/rev/swerve/RevSwerveModuleConstantsTest.java
@@ -1,0 +1,32 @@
+package com.gos.lib.rev.swerve;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RevSwerveModuleConstantsTest {
+
+    @Test
+    public void test12Teeth() {
+        RevSwerveModuleConstants.DriveMotorTeeth teeth = RevSwerveModuleConstants.DriveMotorTeeth.T12;
+
+        RevSwerveModuleConstants constants = new RevSwerveModuleConstants(teeth);
+        assertEquals(5.50, constants.m_drivingMotorReduction, 1e-2);
+    }
+
+    @Test
+    public void test13Teeth() {
+        RevSwerveModuleConstants.DriveMotorTeeth teeth = RevSwerveModuleConstants.DriveMotorTeeth.T13;
+
+        RevSwerveModuleConstants constants = new RevSwerveModuleConstants(teeth);
+        assertEquals(5.08, constants.m_drivingMotorReduction, 1e-2);
+    }
+
+    @Test
+    public void test14Teeth() {
+        RevSwerveModuleConstants.DriveMotorTeeth teeth = RevSwerveModuleConstants.DriveMotorTeeth.T14;
+
+        RevSwerveModuleConstants constants = new RevSwerveModuleConstants(teeth);
+        assertEquals(4.71, constants.m_drivingMotorReduction, 1e-2);
+    }
+}

--- a/libraries/GirlsOfSteelLibRev/vendordeps/SnobotSim.json
+++ b/libraries/GirlsOfSteelLibRev/vendordeps/SnobotSim.json
@@ -1,0 +1,22 @@
+{
+  "fileName": "SnobotSim.json",
+  "name": "SnobotSim",
+  "version": "2023.10.28-18",
+  "uuid": "88e2fcb0-75bd-11ee-b0bf-396770175b4a",
+  "mavenUrls": ["https://raw.githubusercontent.com/snobotsim/maven_repo/master/release"],
+  "jsonUrl": "http://raw.githubusercontent.com/snobotsim/maven_repo/master/release/SnobotSim.json",
+  "javaDependencies": [
+    {
+      "groupId": "org.snobotv2",
+      "artifactId": "snobot_sim_java",
+      "version": "2023.10.28-18"
+    },
+    {
+      "groupId": "org.snobotv2",
+      "artifactId": "snobot_swerve_sim",
+      "version": "2023.10.28-18"
+    }
+  ],
+  "jniDependencies": [],
+  "cppDependencies": []
+}

--- a/y2023/ChargedUp/simgui.json
+++ b/y2023/ChargedUp/simgui.json
@@ -89,8 +89,11 @@
       "/Shuffleboard/AutomatedTurret/Mid Cube": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis Auto Engage": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis Speed (0,0,1)": "Command",
+      "/Shuffleboard/ChassisTestCommands/Chassis Speed (0,0,360deg)": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis Speed (0,1,0)": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis Speed (1,0,0)": "Command",
+      "/Shuffleboard/ChassisTestCommands/Chassis Speeds Percent 0% 100%": "Command",
+      "/Shuffleboard/ChassisTestCommands/Chassis Speeds Percent 0% 5%": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis To Angle 0": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis To Angle 180": "Command",
       "/Shuffleboard/ChassisTestCommands/Chassis set position: (0, 0, -90 deg)": "Command",
@@ -540,26 +543,16 @@
     "Plot <0>": {
       "plots": [
         {
-          "height": 324,
+          "axis": [
+            {
+              "autoFit": true
+            },
+            {
+              "autoFit": true
+            }
+          ],
+          "height": 403,
           "series": [
-            {
-              "color": [
-                0.2980392277240753,
-                0.44705885648727417,
-                0.6901960968971252,
-                1.0
-              ],
-              "id": "NT:/SwerveDrive/FR/Current Angle"
-            },
-            {
-              "color": [
-                0.8666667342185974,
-                0.5176470875740051,
-                0.32156863808631897,
-                1.0
-              ],
-              "id": "NT:/SwerveDrive/FR/Goal Angle"
-            },
             {
               "color": [
                 0.3333333432674408,
@@ -577,8 +570,29 @@
                 1.0
               ],
               "id": "NT:/SwerveDrive/FR/Current Velocity"
+            },
+            {
+              "color": [
+                0.2980392277240753,
+                0.44705885648727417,
+                0.6901960968971252,
+                1.0
+              ],
+              "id": "NT:/SwerveDrive/FR/Current Angle",
+              "yAxis": 1
+            },
+            {
+              "color": [
+                0.8666667342185974,
+                0.5176470875740051,
+                0.32156863808631897,
+                1.0
+              ],
+              "id": "NT:/SwerveDrive/FR/Goal Angle",
+              "yAxis": 1
             }
-          ]
+          ],
+          "yaxis2": true
         }
       ]
     }

--- a/y2023/ChargedUp/src/main/java/com/gos/chargedup/RobotContainer.java
+++ b/y2023/ChargedUp/src/main/java/com/gos/chargedup/RobotContainer.java
@@ -350,14 +350,10 @@ public class RobotContainer {
 
     private void resetStickyFaults() {
         m_pneumaticHub.clearStickyFaults();
-        clearStickyFaultsPDH();
-        m_chassisSubsystem.resetStickyFaultsChassis();
-        m_armPivot.clearStickyFaultsArmPivot();
-        m_claw.clearStickyFaultsClaw();
-    }
-
-    private void clearStickyFaultsPDH() {
         m_powerDistribution.clearStickyFaults();
+        m_chassisSubsystem.clearStickyFaults();
+        m_armPivot.clearStickyFaults();
+        m_claw.clearStickyFaults();
     }
 
     private CommandBase createResetStickyFaults() {

--- a/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/ArmPivotSubsystem.java
+++ b/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/ArmPivotSubsystem.java
@@ -362,7 +362,7 @@ public class ArmPivotSubsystem extends SubsystemBase {
         return isMotionProfileFinished() && Math.abs(error) <= allowableError && Math.abs(velocity) < allowableVelocityError;
     }
 
-    public void clearStickyFaultsArmPivot() {
+    public void clearStickyFaults() {
         m_pivotMotor.clearFaults();
     }
 

--- a/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/ChassisSubsystemInterface.java
+++ b/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/ChassisSubsystemInterface.java
@@ -40,7 +40,7 @@ public interface ChassisSubsystemInterface extends Subsystem {
 
     boolean canExtendArm();
 
-    void resetStickyFaultsChassis();
+    void clearStickyFaults();
 
     CommandBase createDriveToPointCommand(Pose2d point, boolean reverse);
 

--- a/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/ClawSubsystem.java
+++ b/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/ClawSubsystem.java
@@ -85,7 +85,7 @@ public class ClawSubsystem extends SubsystemBase {
         m_clawMotorErrorAlerts.checkAlerts();
     }
 
-    public void clearStickyFaultsClaw() {
+    public void clearStickyFaults() {
         m_clawMotor.clearFaults();
     }
 

--- a/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/SwerveDriveChassisSubsystem.java
+++ b/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/SwerveDriveChassisSubsystem.java
@@ -3,32 +3,23 @@ package com.gos.chargedup.subsystems;
 
 import com.gos.chargedup.Constants;
 import com.gos.chargedup.GosSwerveAutoBuilder;
-import com.gos.chargedup.SwerveDrivePublisher;
 import com.gos.lib.properties.pid.PidProperty;
 import com.gos.lib.properties.pid.WpiPidPropertyBuilder;
+import com.gos.lib.rev.swerve.RevSwerveChassis;
+import com.gos.lib.rev.swerve.RevSwerveChassisConstants;
+import com.gos.lib.rev.swerve.RevSwerveModuleConstants;
 import com.pathplanner.lib.auto.BaseAutoBuilder;
 import com.pathplanner.lib.commands.PPSwerveControllerCommand;
 import edu.wpi.first.math.controller.PIDController;
-import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
-import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
-import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
-import edu.wpi.first.math.kinematics.SwerveModulePosition;
-import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import org.snobotv2.module_wrappers.ctre.CtrePigeonImuWrapper;
-import org.snobotv2.sim_wrappers.SwerveModuleSimWrapper;
-import org.snobotv2.sim_wrappers.SwerveSimWrapper;
 
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -40,29 +31,6 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
     public static final double MAX_TRANSLATION_SPEED = 2.9;
     public static final double MAX_ROTATION_SPEED = Units.degreesToRadians(180);
 
-    private static final Translation2d FRONT_LEFT_LOCATION = new Translation2d(WHEEL_BASE / 2, TRACK_WIDTH / 2);
-    private static final Translation2d FRONT_RIGHT_LOCATION = new Translation2d(WHEEL_BASE / 2, -TRACK_WIDTH / 2);
-    private static final Translation2d BACK_LEFT_LOCATION = new Translation2d(-WHEEL_BASE / 2, TRACK_WIDTH / 2);
-    private static final Translation2d BACK_RIGHT_LOCATION = new Translation2d(-WHEEL_BASE / 2, -TRACK_WIDTH / 2);
-
-    // Creating my kinematics object using the module locations
-    private static final SwerveDriveKinematics SWERVE_KINEMATICS = new SwerveDriveKinematics(
-        FRONT_LEFT_LOCATION, FRONT_RIGHT_LOCATION, BACK_LEFT_LOCATION, BACK_RIGHT_LOCATION
-    );
-
-    private final SwerveDriveModules m_frontLeft;
-    private final SwerveDriveModules m_backLeft;
-    private final SwerveDriveModules m_frontRight;
-    private final SwerveDriveModules m_backRight;
-
-    private final SwerveDriveModules[] m_modules;
-
-    private final SwerveDriveOdometry m_odometry;
-    private final SwerveDrivePoseEstimator m_poseEstimator;
-
-    private final SwerveDrivePublisher m_swervePublisher;
-
-
     private final PIDController m_xTranslationPidController;
     private final PIDController m_yTranslationPidController;
     private final PIDController m_rotationPidController;
@@ -70,21 +38,20 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
     private final PidProperty m_yTranslationPidProperties;
     private final PidProperty m_rotationPidProperties;
 
-    private SwerveSimWrapper m_simulator;
+    private final RevSwerveChassis m_swerveDrive;
 
     public SwerveDriveChassisSubsystem() {
-        m_frontLeft = new SwerveDriveModules("FL", Constants.FRONT_LEFT_WHEEL, Constants.FRONT_LEFT_AZIMUTH,  -Math.PI / 2);
-        m_frontRight = new SwerveDriveModules("FR", Constants.FRONT_RIGHT_WHEEL, Constants.FRONT_RIGHT_AZIMUTH, 0);
-        m_backLeft = new SwerveDriveModules("BL", Constants.BACK_LEFT_WHEEL, Constants.BACK_LEFT_AZIMUTH, Math.PI);
-        m_backRight = new SwerveDriveModules("BR", Constants.BACK_RIGHT_WHEEL, Constants.BACK_RIGHT_AZIMUTH, Math.PI / 2);
-        m_modules = new SwerveDriveModules[]{m_frontLeft, m_frontRight, m_backLeft, m_backRight};
-
-        m_odometry = new SwerveDriveOdometry(
-            SWERVE_KINEMATICS, m_gyro.getRotation2d(),
-            getModulePositions(), new Pose2d());
-        m_poseEstimator = new SwerveDrivePoseEstimator(SWERVE_KINEMATICS, m_gyro.getRotation2d(), getModulePositions(), new Pose2d());
-
-        m_swervePublisher = new SwerveDrivePublisher();
+        RevSwerveChassisConstants swerveConstants = new RevSwerveChassisConstants(
+            Constants.FRONT_LEFT_WHEEL, Constants.FRONT_LEFT_AZIMUTH,
+            Constants.BACK_LEFT_WHEEL, Constants.BACK_LEFT_AZIMUTH,
+            Constants.FRONT_RIGHT_WHEEL, Constants.FRONT_RIGHT_AZIMUTH,
+            Constants.BACK_RIGHT_WHEEL, Constants.BACK_RIGHT_AZIMUTH,
+            RevSwerveModuleConstants.DriveMotorTeeth.T14,
+            WHEEL_BASE, TRACK_WIDTH,
+            MAX_TRANSLATION_SPEED,
+            MAX_ROTATION_SPEED
+        );
+        m_swerveDrive = new RevSwerveChassis(swerveConstants, m_gyro::getRotation2d, new CtrePigeonImuWrapper(m_gyro));
 
         m_xTranslationPidController = new PIDController(0, 0, 0);
         m_xTranslationPidProperties = new WpiPidPropertyBuilder("SwerveTranslation", false, m_xTranslationPidController)
@@ -110,15 +77,6 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
             this::logTrajectoryChassisSetpoint,
             this::logTrajectoryErrors
         );
-
-        if (RobotBase.isSimulation()) {
-            List<SwerveModuleSimWrapper> moduleSims = List.of(
-                m_frontLeft.getSimWrapper(),
-                m_frontRight.getSimWrapper(),
-                m_backLeft.getSimWrapper(),
-                m_backRight.getSimWrapper());
-            m_simulator = new SwerveSimWrapper(WHEEL_BASE, TRACK_WIDTH, 64.0, 1.0, moduleSims, new CtrePigeonImuWrapper(m_gyro));
-        }
     }
 
     private void logTrajectoryChassisSetpoint(ChassisSpeeds chassisSpeeds) {
@@ -129,39 +87,12 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
 
     @Override
     protected void lockDriveTrain() {
-        m_frontLeft.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(45)));
-        m_frontRight.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(-45)));
-        m_backLeft.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(-45)));
-        m_backRight.setDesiredState(new SwerveModuleState(0, Rotation2d.fromDegrees(45)));
+        m_swerveDrive.setWheelsToXShape();
     }
 
     @Override
     protected void unlockDriveTrain() {
         // TODO implement
-    }
-
-    public final SwerveModulePosition[] getModulePositions() {
-        SwerveModulePosition[] modulePositions = new SwerveModulePosition[4];
-        for (int i = 0; i < 4; i += 1) {
-            modulePositions[i] = m_modules[i].getPosition();
-        }
-        return modulePositions;
-    }
-
-    public SwerveModuleState[] getModuleStates() {
-        SwerveModuleState[] modulePositions = new SwerveModuleState[4];
-        for (int i = 0; i < 4; i += 1) {
-            modulePositions[i] = m_modules[i].getState();
-        }
-        return modulePositions;
-    }
-
-    private SwerveModuleState[] getModuleDesiredStates() {
-        SwerveModuleState[] modulePositions = new SwerveModuleState[4];
-        for (int i = 0; i < 4; i += 1) {
-            modulePositions[i] = m_modules[i].getDesiredState();
-        }
-        return modulePositions;
     }
 
     @Override
@@ -170,54 +101,24 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
         m_yTranslationPidProperties.updateIfChanged();
         m_rotationPidProperties.updateIfChanged();
 
-        for (SwerveDriveModules module : m_modules) {
-            module.periodic();
-        }
+        m_swerveDrive.periodic();
 
-        SwerveModulePosition[] modulePositions = getModulePositions();
-        m_odometry.update(m_gyro.getRotation2d(), modulePositions);
-        m_poseEstimator.update(m_gyro.getRotation2d(), modulePositions);
-
-        m_field.setOdometry(m_odometry.getPoseMeters());
-        m_field.setPoseEstimate(m_poseEstimator.getEstimatedPosition());
-
-        SwerveModuleState[] moduleStates = getModuleStates();
-        SwerveModuleState[] desiredStates = getModuleDesiredStates();
-        m_swervePublisher.setMeasuredStates(moduleStates);
-        m_swervePublisher.setDesiredStates(desiredStates);
-        m_swervePublisher.setRobotRotation(getPose().getRotation());
+        m_field.setOdometry(m_swerveDrive.getOdometryPosition());
+        m_field.setPoseEstimate(m_swerveDrive.getEstimatedPosition());
     }
 
     @Override
     public void simulationPeriodic() {
-        m_simulator.update();
+        m_swerveDrive.updateSimulator();
     }
 
     public void setSpeeds(ChassisSpeeds speedsInp) {
-        SwerveModuleState[] moduleStates = SWERVE_KINEMATICS.toSwerveModuleStates(speedsInp);
-        SwerveDriveKinematics.desaturateWheelSpeeds(moduleStates, MAX_TRANSLATION_SPEED);
-        setModuleStates(moduleStates);
-    }
-
-    public void setModuleStates(SwerveModuleState... moduleStates) {
-        for (int i = 0; i < 4; i++) {
-            m_modules[i].setDesiredState(moduleStates[i]);
-        }
-    }
-
-    public void setChassisSpeedsPercent(double wheelPercent, double azimuthPercent) {
-        for (SwerveDriveModules module: m_modules) {
-            module.setSpeedPercent(azimuthPercent, wheelPercent);
-        }
-    }
-
-    public void setModuleState(int moduleId, double degrees, double velocity) {
-        m_modules[moduleId].setDesiredState(new SwerveModuleState(velocity, Rotation2d.fromDegrees(degrees)));
+        m_swerveDrive.setChassisSpeeds(speedsInp);
     }
 
     @Override
-    public void resetStickyFaultsChassis() {
-        // TODO implement
+    public void clearStickyFaults() {
+        m_swerveDrive.clearStickyFaults();
     }
 
     @Override
@@ -236,12 +137,12 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
 
     @Override
     public Pose2d getPose() {
-        return m_poseEstimator.getEstimatedPosition();
+        return m_swerveDrive.getEstimatedPosition();
     }
 
     @Override
     public void stop() {
-        // TODO implement
+        m_swerveDrive.stop();
     }
 
     @Override
@@ -256,8 +157,7 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
 
     @Override
     public void resetOdometry(Pose2d pose2d) {
-        m_odometry.resetPosition(m_gyro.getRotation2d(), getModulePositions(), pose2d);
-        m_poseEstimator.resetPosition(m_gyro.getRotation2d(), getModulePositions(), pose2d);
+        m_swerveDrive.resetOdometry(pose2d);
     }
 
     @Override
@@ -268,18 +168,13 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
 
     @Override
     public CommandBase createSyncOdometryWithPoseEstimatorCommand() {
-        return runOnce(() ->  m_odometry.resetPosition(m_gyro.getRotation2d(), getModulePositions(), m_poseEstimator.getEstimatedPosition()))
-        .withName("Sync Odometry /w Pose");
+        return runOnce(m_swerveDrive::syncOdometryWithPoseEstimator).withName("Sync Odometry /w Pose");
     }
 
     @Override
     public CommandBase createSelfTestMotorsCommand() {
         // TODO implement
         return new SequentialCommandGroup();
-    }
-
-    public CommandBase commandSetModuleState(int moduleId, double degrees, double velocity) {
-        return this.run(() -> setModuleState(moduleId, degrees, velocity)).withName("Module " + moduleId + "(" + degrees + ", " + velocity + ")");
     }
 
     public CommandBase commandSetChassisSpeed(ChassisSpeeds chassisSp) {
@@ -290,8 +185,12 @@ public class SwerveDriveChassisSubsystem extends BaseChassis {
         return this.run(this::lockDriveTrain).withName("Lock Wheels Command");
     }
 
+    public CommandBase commandSetModuleState(int moduleId, double degrees, double velocity) {
+        return this.run(() -> m_swerveDrive.setModuleState(moduleId, degrees, velocity)).withName("Module " + moduleId + "(" + degrees + ", " + velocity + ")");
+    }
+
     public CommandBase commandSetPercentSpeeds(double percentAzimuth, double percentWheel) {
-        return this.run(() -> setChassisSpeedsPercent(percentWheel, percentAzimuth));
+        return this.run(() -> m_swerveDrive.setChassisSpeedsPercent(percentWheel, percentAzimuth));
     }
 
 }

--- a/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/TankDriveChassisSubsystem.java
+++ b/y2023/ChargedUp/src/main/java/com/gos/chargedup/subsystems/TankDriveChassisSubsystem.java
@@ -375,7 +375,7 @@ public class TankDriveChassisSubsystem extends BaseChassis implements ChassisSub
     }
 
     @Override
-    public void resetStickyFaultsChassis() {
+    public void clearStickyFaults() {
         m_leaderLeft.clearFaults();
         m_leaderRight.clearFaults();
         m_followerLeft.clearFaults();


### PR DESCRIPTION
Moves the module and a base swerve drive to the shared libraries. The base swerve drive has built in odometry / pose estimation and telemetry publishing.