### PR TITLE
Fix Phoenix6PidBuilder to use custom values

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+GirlsOfSteelRobotics

--- a/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/pid/PidProperty.java
+++ b/libraries/GirlsOfSteelLib/src/main/java/com/gos/lib/properties/pid/PidProperty.java
@@ -11,8 +11,7 @@ import java.util.function.DoubleConsumer;
 public class PidProperty {
     private final List<HeavyDoubleProperty> m_properties;
 
-
-    /* default */ PidProperty(List<HeavyDoubleProperty> properties) {
+    /* default */  public PidProperty(List<HeavyDoubleProperty> properties) {
         m_properties = properties;
     }
 

--- a/libraries/GirlsOfSteelLibPhoenix6/src/main/java/com/gos/lib/phoenix6/properties/pid/Phoenix6TalonPidPropertyBuilder.java
+++ b/libraries/GirlsOfSteelLibPhoenix6/src/main/java/com/gos/lib/phoenix6/properties/pid/Phoenix6TalonPidPropertyBuilder.java
@@ -3,12 +3,11 @@ package com.gos.lib.phoenix6.properties.pid;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.Slot1Configs;
 import com.ctre.phoenix6.configs.Slot2Configs;
-import com.ctre.phoenix6.hardware.core.CoreTalonFX;
 import com.ctre.phoenix6.configs.SlotConfigs;
+import com.ctre.phoenix6.hardware.core.CoreTalonFX;
 import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.gos.lib.properties.GosDoubleProperty;
 import com.gos.lib.properties.HeavyDoubleProperty;
-import com.gos.lib.properties.pid.IPidPropertyBuilder;
 import com.gos.lib.properties.pid.PidProperty;
 
 import java.util.ArrayList;

--- a/libraries/GirlsOfSteelLibPhoenix6/src/main/java/com/gos/lib/phoenix6/properties/pid/Phoenix6TalonPidPropertyBuilder.java
+++ b/libraries/GirlsOfSteelLibPhoenix6/src/main/java/com/gos/lib/phoenix6/properties/pid/Phoenix6TalonPidPropertyBuilder.java
@@ -6,17 +6,30 @@ import com.ctre.phoenix6.configs.Slot2Configs;
 import com.ctre.phoenix6.hardware.core.CoreTalonFX;
 import com.ctre.phoenix6.configs.SlotConfigs;
 import com.ctre.phoenix6.signals.GravityTypeValue;
+import com.gos.lib.properties.GosDoubleProperty;
+import com.gos.lib.properties.HeavyDoubleProperty;
 import com.gos.lib.properties.pid.IPidPropertyBuilder;
 import com.gos.lib.properties.pid.PidProperty;
 
-public final class Phoenix6TalonPidPropertyBuilder extends PidProperty.Builder implements IPidPropertyBuilder {
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.DoubleConsumer;
+
+public final class Phoenix6TalonPidPropertyBuilder {
     private final CoreTalonFX m_motor;
     private final SlotConfigs m_slot;
+    private final boolean m_isConstant;
+    private final String m_baseName;
+    private final List<HeavyDoubleProperty> m_props;
 
     @SuppressWarnings("PMD.ImplicitSwitchFallThrough")
     public Phoenix6TalonPidPropertyBuilder(String baseName, boolean isConstant, CoreTalonFX motor, int slot) {
-        super(baseName, isConstant);
+        m_isConstant = isConstant;
+        m_baseName = baseName;
         m_motor = motor;
+
+        m_props = new ArrayList<>();
+
         switch (slot) {
         case 1:
             m_slot = SlotConfigs.from(new Slot1Configs());
@@ -30,78 +43,71 @@ public final class Phoenix6TalonPidPropertyBuilder extends PidProperty.Builder i
         }
     }
 
-    @Override
-    public IPidPropertyBuilder addP(double defaultValue) {
-        addP(defaultValue, (double gain) -> {
+    private HeavyDoubleProperty createDoubleProperty(String propertyNameSuffix, double defaultValue, DoubleConsumer setter) {
+        String propertyName = m_baseName + ".mm." + propertyNameSuffix;
+        GosDoubleProperty prop = new GosDoubleProperty(m_isConstant, propertyName, defaultValue);
+
+        return new HeavyDoubleProperty(setter, prop);
+    }
+
+    public Phoenix6TalonPidPropertyBuilder addP(double defaultValue) {
+        m_props.add(createDoubleProperty("kp", defaultValue, (double gain) -> {
             m_slot.kP = gain;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    @Override
-    public IPidPropertyBuilder addI(double defaultValue) {
-        addI(defaultValue, (double gain) -> {
+    public Phoenix6TalonPidPropertyBuilder addI(double defaultValue) {
+        m_props.add(createDoubleProperty("ki", defaultValue, (double gain) -> {
             m_slot.kI = gain;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    @Override
-    public IPidPropertyBuilder addD(double defaultValue) {
-        addD(defaultValue, (double gain) -> {
+    public Phoenix6TalonPidPropertyBuilder addD(double defaultValue) {
+        m_props.add(createDoubleProperty("kD", defaultValue, (double gain) -> {
             m_slot.kD = gain;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    public IPidPropertyBuilder addKV(double defaultValue) {
-        addGenericProperty("kV", defaultValue, (double gain) -> {
+    public Phoenix6TalonPidPropertyBuilder addKV(double defaultValue) {
+        m_props.add(createDoubleProperty("kV", defaultValue, (double gain) -> {
             m_slot.kV = gain;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    public IPidPropertyBuilder addKS(double defaultValue) {
-        addGenericProperty("kS", defaultValue, (double gain) -> {
+    public Phoenix6TalonPidPropertyBuilder addKS(double defaultValue) {
+        m_props.add(createDoubleProperty("kS", defaultValue, (double gain) -> {
             m_slot.kS = gain;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    public IPidPropertyBuilder addKG(double defaultValue, GravityTypeValue gravityType) {
-        addGenericProperty("kG", defaultValue, (double gain) -> {
+    public Phoenix6TalonPidPropertyBuilder addKG(double defaultValue, GravityTypeValue gravityType) {
+        m_props.add(createDoubleProperty("kG", defaultValue, (double gain) -> {
             m_slot.kG = gain;
             m_slot.GravityType = gravityType;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    public IPidPropertyBuilder addKA(double defaultValue) {
-        addGenericProperty("kA", defaultValue, (double gain) -> {
+    public Phoenix6TalonPidPropertyBuilder addKA(double defaultValue) {
+        m_props.add(createDoubleProperty("kA", defaultValue, (double gain) -> {
             m_slot.kA = gain;
             m_motor.getConfigurator().apply(m_slot);
-        });
+        }));
         return this;
     }
 
-    @Override
-    public IPidPropertyBuilder addFF(double defaultValue) {
-        throw new RuntimeException("Method Builder.addFF() doesn't work for the PhoenixV6 TalonFX. Try addKS(), addKV(), addKG(), and addKA() instead.");
-    }
-
-    @Override
-    public IPidPropertyBuilder addMaxVelocity(double defaultValue) {
-        throw new RuntimeException("Method Builder.addMaxVelocity() doesn't work for the PhoenixV6 TalonFX. Try setting up Feedforward values and using a MotionMagic control request instead.");
-    }
-
-    @Override
-    public IPidPropertyBuilder addMaxAcceleration(double defaultValue) {
-        throw new RuntimeException("Method Builder.addFF() doesn't work for the PhoenixV6 TalonFX. Try using addKA() or MotionMagic");
+    public PidProperty build() {
+        return new PidProperty(m_props);
     }
 }


### PR DESCRIPTION
I realized when I wrote the original code, I implemented and extended the basic `IPidBuilder` and `PidProperty`.Builder classes/interfaces, which works up until I call the first `.addP()` method. It then returns a generic `IPidBuilder`, which doesn't have the methods for `kV`, `kS`, `kA`, and `kG` that the Phoenix 6 TalonFX needs. This version makes it it's own classes that still follows the same structure as the `IPidBuilder` interface, but without implementing or extending anything. The one catch is that I had to make the default constructor for `PidProperty` public to be able to build the Phoenix 6 builder. Feel free to suggest a better method if you don't like this one.